### PR TITLE
fixed language server only running for filetypes with tree-sitter Language

### DIFF
--- a/harper-ls/src/tree_sitter_parser.rs
+++ b/harper-ls/src/tree_sitter_parser.rs
@@ -30,7 +30,7 @@ impl TreeSitterParser {
             "csharp" => tree_sitter_c_sharp::language(),
             "toml" => tree_sitter_toml::language(),
             "lua" => tree_sitter_lua::language(),
-            _ => return None
+            _ => tree_sitter_toml::language()
         };
 
         let comment_parser: Box<dyn Parser> = match language_id {


### PR DESCRIPTION
I found that even when I setup lspconfig with something like this:
```lua
lspconfig.harper_ls.setup {
    filetypes = { "markdown", "text", "lua" },
}
```
that the harper linter would only run for lua files, not markdown or text files. I realized that this is because if `new_from_language_id` returns `None`, the linter simply wouldn't run. So I instead had the wildcard pattern return an arbitrary tree-sitter Language, and it fixed the problem.