### PR TITLE
It is better to use the repository field

### DIFF
--- a/harper-ls/Cargo.toml
+++ b/harper-ls/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 description = "The language checker for developers."
 license = "Apache-2.0"
 readme = "README.md"
-homepage = "https://github.com/elijah-potter/harper"
+repository = "https://github.com/elijah-potter/harper"
 
 [dependencies]
 harper-core = { path = "../harper-core", version = "0.8.0" }


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See also [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field).