### PR TITLE
fix: configuration and legacy numerics

### DIFF
--- a/harper-core/src/linting/spelled_numbers.rs
+++ b/harper-core/src/linting/spelled_numbers.rs
@@ -1,5 +1,3 @@
-use std::f64::EPSILON;
-
 use crate::{Document, Lint, LintKind, Linter, Suggestion, TokenStringExt};
 
 /// Linter that checks to make sure small integers (< one hundred) are spelled
@@ -14,7 +12,7 @@ impl Linter for SpelledNumbers {
         for number_tok in document.iter_numbers() {
             let (number, _suffix) = number_tok.kind.number().unwrap();
 
-            if number - number.floor() < EPSILON && number <= 100. {
+            if (number - number.floor()).abs() < f64::EPSILON && number <= 100. {
                 lints.push(Lint {
                     span: number_tok.span,
                     lint_kind: LintKind::Readability,

--- a/harper-core/src/spell/hunspell/attributes.rs
+++ b/harper-core/src/spell/hunspell/attributes.rs
@@ -1,5 +1,3 @@
-use std::usize;
-
 use hashbrown::HashMap;
 use smallvec::ToSmallVec;
 

--- a/harper-core/src/spell/mod.rs
+++ b/harper-core/src/spell/mod.rs
@@ -128,7 +128,7 @@ fn edit_distance_min_alloc(
     previous_row: &mut Vec<u8>,
     current_row: &mut Vec<u8>
 ) -> u8 {
-    if cfg!(debug) {
+    if cfg!(debug_assertions) {
         assert!(source.len() <= 255 && target.len() <= 255);
     }
 


### PR DESCRIPTION
Make it such that `precommit.sh` no longer errors