### PR TITLE
fix: remove dbg

### DIFF
--- a/harper-comments/src/comment_parsers/unit.rs
+++ b/harper-comments/src/comment_parsers/unit.rs
@@ -71,7 +71,5 @@ fn line_is_code_fence(source: &[char]) -> bool {
     let actual = without_initiators(source);
     let actual_chars = actual.get_content(source);
 
-    dbg!(actual_chars);
-
     matches!(actual_chars, ['`', '`', '`', ..])
 }


### PR DESCRIPTION
One day ago, [a commit](https://github.com/elijah-potter/harper/commit/bd21b53530469d2b18283ab0aeabdedf8a3342ed) addressing issue #132 introduced a debug statement that pollutes CLI output when running `just dogfood`