### PR TITLE
fix: speed up `just dogfood` execution

### DIFF
--- a/justfile
+++ b/justfile
@@ -89,10 +89,11 @@ install:
 # Run `harper-cli` on the Harper repository
 dogfood:
   #! /bin/bash
+  cargo build --release
   for file in `fd -e rs`
   do
     echo Linting $file
-    cargo run --bin harper-cli --release --quiet -- lint $file
+    ./target/release/harper-cli lint $file
   done
 
 test:


### PR DESCRIPTION
Shortly after installation, I ran `just dogfood` in order to gauge the speed of Harper on my machine . It seemed slow, each file taking almost a second to lint. 

The call to `cargo run --release` adds a decent amount of overhead to each file in the loop, so instead we can use `cargo build --release` once before the loop to ensure the binary is built, and then run the binary directly within the loop. After this change, each file lints in ~200ms instead of ~1s