### PR TITLE
feat: allow to configure file dictionary path

### DIFF
--- a/harper-ls/README.md
+++ b/harper-ls/README.md
@@ -42,13 +42,14 @@ You can add to the user dictionary with code actions on misspelled words.
 #### Configuration
 
 You don't have to stick with the default locations (listed above).
-If you use Neovim, you can set the location of the dictionary with the `userDictPath` key:
+If you use Neovim, you can set the location of the user dictionary with the `userDictPath` key, and the file dictionary with the `fileDictPath` key:
 
 ```lua
 lspconfig.harper_ls.setup {
   settings = {
     ["harper-ls"] = {
-      userDictPath = "~/dict.txt"
+      userDictPath = "~/dict.txt",
+      fileDictPath = "~/.harper/",
     }
   },
 }

--- a/harper-ls/src/config.rs
+++ b/harper-ls/src/config.rs
@@ -93,6 +93,14 @@ impl Config {
             }
         }
 
+        if let Some(v) = value.get("fileDictPath") {
+            if let Value::String(path) = v {
+                base.file_dict_path = path.try_resolve()?.to_path_buf();
+            } else {
+                return Err(anyhow::format_err!("fileDict path must be a string."));
+            }
+        }
+
         if let Some(v) = value.get("linters") {
             base.lint_config = serde_json::from_value(v.clone())?;
         }


### PR DESCRIPTION
Adds `fileDictPath` configuration, akin to `userDictPath`.

The implementation and documentation mirror the existing implementation of `userDictPath`, and hence only make the smallest set of changes required to provide a configurable file dictionary path.