### PR TITLE
fix: test 'spell::hunspell::tests::correctly_expands_test_files' failed

### DIFF
--- a/harper-core/src/spell/hunspell/mod.rs
+++ b/harper-core/src/spell/hunspell/mod.rs
@@ -28,7 +28,7 @@ pub fn parse_default_attribute_list() -> AttributeList {
 
 #[cfg(test)]
 mod tests {
-    use hashbrown::HashMap;
+    use hashbrown::{HashMap, HashSet};
     use serde_json::json;
 
     use super::word_list::parse_word_list;
@@ -88,7 +88,7 @@ mod tests {
         let mut expanded = HashMap::new();
 
         attributes.expand_marked_words(words, &mut expanded);
-        let expanded: Vec<String> = expanded
+        let expanded: HashSet<String> = expanded
             .into_iter()
             .map(|v| v.0.into_iter().collect())
             .collect();
@@ -96,6 +96,9 @@ mod tests {
         assert_eq!(
             expanded,
             vec!["hello", "tried", "reworked", "rework", "worked", "work", "try"]
+                .into_iter()
+                .map(|v| v.into())
+                .collect()
         )
     }
 


### PR DESCRIPTION
The test [`spell::hunspell::tests::correctly_expands_test_files`](https://github.com/Cryolitia/harper/blob/4e6564a9b9c120396972d984ba2a950dc6db18f9/harper-core/src/spell/hunspell/mod.rs#L88-L100) iterates over a HashMap and collects the results, but the results assume that the collected array is in a specific order. Rust does not guarantee the order in which HashMap is iterated, and the order depends on the specific implementation of Rust's hash function on the platform.

It is on the [Rust Doc](https://doc.rust-lang.org/std/collections/struct.HashMap.html#method.iter) that said:

> An iterator visiting all key-value pairs in **arbitrary order**. The iterator element type is `(&'a K, &'a V)`.

> Due to differences in endianness and type sizes, data fed by Hash to a Hasher should not be considered portable across platforms. Additionally the data passed by most standard library types should not be considered stable between compiler versions.

Specifically, I found that so far, the results of running this test on different platforms are:

- [x] x86_64-linux
- [x] aarch64-linux
- [ ] riscv64-linux (SG2042)
- [ ] riscv64-linux (qemu-user)
- [ ] loongarch64-linux (3A5000)

On all of SG2042, qemu-user-riscv64, 3A5000, this test will fail with the same output:

```log
failures:

---- spell::hunspell::tests::correctly_expands_test_files stdout ----
thread 'spell::hunspell::tests::correctly_expands_test_files' panicked at harper-core/src/spell/hunspell/mod.rs:96:9:
assertion `left == right` failed
  left: ["try", "tried", "rework", "work", "worked", "hello", "reworked"]
 right: ["hello", "tried", "reworked", "rework", "worked", "work", "try"]
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    spell::hunspell::tests::correctly_expands_test_files
```

This patch has been tested on:

- [x] x86_64-linux
- [x] aarch64-linux
- [x] riscv64-linux (SG2042)
- [x] riscv64-linux (qemu-user)
- [x] loongarch64-linux

Reported-by: https://archriscv.felixc.at/.status/log.htm?url=logs/harper/harper-0.10.0-1.log