### PR TITLE
dict: add TCP, UDP and QUIC to the default dictionary.

### DIFF
--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -49686,3 +49686,6 @@ Foddy/SM
 Hasan/SM
 Sharman/SM
 Labriola/SM
+TCP/SM
+UDP/SM
+QUIC/SM

--- a/justfile
+++ b/justfile
@@ -130,7 +130,7 @@ addnoun noun:
   #! /bin/bash
   DICT_FILE=./harper-core/dictionary.dict 
 
-  cat $DICT_FILE | grep {{noun}} 
+  cat $DICT_FILE | grep "^{{noun}}/"
 
   if [ $? -eq 0 ]
   then


### PR DESCRIPTION
Adds TCP, UDP and QUIC to the default dictionary. I wasn't sure about adding lowercase acronyms. Does harper support them?