### PR TITLE
feat: pin nightly version of latest stable rust and add a `just check-rust` command

### DIFF
--- a/.github/workflows/build_harper_ls.yml
+++ b/.github/workflows/build_harper_ls.yml
@@ -54,6 +54,7 @@ jobs:
       - name: Build binary
         uses: houseabsolute/actions-rust-cross@v0
         with:
+          toolchain: nightly # we use the nightly version of the latest stable rustc
           command: ${{ matrix.platform.command }}
           target: ${{ matrix.platform.target }}
           args: "--locked --release --bin harper-ls"

--- a/justfile
+++ b/justfile
@@ -53,13 +53,19 @@ package-vscode:
   yarn install -f
   yarn package-extension
 
+check-rust:
+  #! /bin/bash
+  set -eo pipefail
+
+  cargo fmt -- --check
+  cargo clippy -- -Dwarnings -D clippy::dbg_macro
+
 # Perform format and type checking.
 check:
   #! /bin/bash
   set -eo pipefail
 
-  cargo +nightly fmt --check
-  cargo clippy -- -Dwarnings -D clippy::dbg_macro
+  just check-rust
 
   cd "{{justfile_directory()}}/packages"
   yarn install

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly-2024-07-18"
+targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
I generally use latest stable rust and found that the project compiles fine with it. However, it looks like harper is using nightly rustfmt arguments. I installed the latest nightly and then found that clippy checks failed. I think it would be useful to pin a specific nightly version using a `rust-toolchain.toml` file.

To fix this, this commit adds a `rust-toolchain.toml` file which installs the nightly version of the latest stable. With the toolchain file, we still get nightly rustfmt features, but everyone uses the same nightly version.

I got the version by going to https://releases.rs and selecting the date at which 1.81 was branched from master.

Also, this added a simple `check-rust` command.