### PR TITLE
Move to stable rustc

### DIFF
--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -18,8 +18,6 @@ jobs:
     - uses: actions/setup-node@v4
       with:
         node-version: 20
-    - name: Install Rust Nightly
-      run: rustup toolchain install nightly && rustup component add rustfmt --toolchain nightly
     - uses: extractions/setup-just@v1
     - name: Install `wasm-pack`
       run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh

--- a/harper-cli/src/main.rs
+++ b/harper-cli/src/main.rs
@@ -19,15 +19,15 @@ enum Args {
         /// Whether to merely print out the number of errors encountered,
         /// without further details.
         #[arg(short, long)]
-        count: bool
+        count: bool,
     },
     /// Parse a provided document and print the detected symbols.
     Parse {
         /// The file you wish to parse.
-        file: PathBuf
+        file: PathBuf,
     },
     /// Emit decompressed, line-separated list of words in Harper's dictionary.
-    Words
+    Words,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -65,7 +65,7 @@ fn main() -> anyhow::Result<()> {
                 report_builder = report_builder.with_label(
                     Label::new((&filename, lint.span.into()))
                         .with_message(lint.message)
-                        .with_color(primary_color)
+                        .with_color(primary_color),
                 );
             }
 
@@ -110,7 +110,7 @@ fn load_file(file: &Path) -> anyhow::Result<(Document, String)> {
             Box::new(
                 CommentParser::new_from_filename(file)
                     .map(Box::new)
-                    .ok_or(format_err!("Could not detect language ID."))?
+                    .ok_or(format_err!("Could not detect language ID."))?,
             )
         };
 

--- a/harper-comments/src/comment_parser.rs
+++ b/harper-comments/src/comment_parser.rs
@@ -9,7 +9,7 @@ use tree_sitter::Node;
 use crate::comment_parsers;
 
 pub struct CommentParser {
-    inner: parsers::Mask<TreeSitterMasker, Box<dyn Parser>>
+    inner: parsers::Mask<TreeSitterMasker, Box<dyn Parser>>,
 }
 
 impl CommentParser {
@@ -35,21 +35,21 @@ impl CommentParser {
             "lua" => tree_sitter_lua::language(),
             "sh" => tree_sitter_bash::language(),
             "java" => tree_sitter_java::language(),
-            _ => return None
+            _ => return None,
         };
 
         let comment_parser: Box<dyn Parser> = match language_id {
             "javascriptreact" | "typescript" | "typescriptreact" | "javascript" => Box::new(JsDoc),
             "java" => Box::new(JavaDoc::default()),
             "go" => Box::new(Go),
-            _ => Box::new(Unit)
+            _ => Box::new(Unit),
         };
 
         Some(Self {
             inner: parsers::Mask::new(
                 TreeSitterMasker::new(language, Self::node_condition),
-                comment_parser
-            )
+                comment_parser,
+            ),
         })
     }
 
@@ -82,7 +82,7 @@ impl CommentParser {
             "sh" => "sh",
             "bash" => "sh",
             "java" => "java",
-            _ => return None
+            _ => return None,
         })
     }
 

--- a/harper-comments/src/comment_parsers/javadoc.rs
+++ b/harper-comments/src/comment_parsers/javadoc.rs
@@ -8,7 +8,7 @@ use super::without_initiators;
 
 #[derive(Default)]
 pub struct JavaDoc {
-    html_parser: HtmlParser
+    html_parser: HtmlParser,
 }
 
 impl Parser for JavaDoc {

--- a/harper-comments/src/comment_parsers/jsdoc.rs
+++ b/harper-comments/src/comment_parsers/jsdoc.rs
@@ -17,7 +17,7 @@ impl Parser for JsDoc {
 
             new_tokens.push(Token::new(
                 Span::new_with_len(line.len(), 1),
-                harper_core::TokenKind::Newline(1)
+                harper_core::TokenKind::Newline(1),
             ));
 
             new_tokens

--- a/harper-comments/src/comment_parsers/unit.rs
+++ b/harper-comments/src/comment_parsers/unit.rs
@@ -32,7 +32,7 @@ impl Parser for Unit {
 
             new_tokens.push(Token::new(
                 Span::new_with_len(line.len(), 1),
-                harper_core::TokenKind::Newline(1)
+                harper_core::TokenKind::Newline(1),
             ));
 
             new_tokens

--- a/harper-core/src/char_ext.rs
+++ b/harper-core/src/char_ext.rs
@@ -31,7 +31,7 @@ impl CharExt for char {
             unicode_blocks::EMOTICONS,
             unicode_blocks::MISCELLANEOUS_SYMBOLS,
             unicode_blocks::VARIATION_SELECTORS,
-            unicode_blocks::SUPPLEMENTAL_SYMBOLS_AND_PICTOGRAPHS
+            unicode_blocks::SUPPLEMENTAL_SYMBOLS_AND_PICTOGRAPHS,
         ];
 
         blocks.contains(&block)
@@ -66,7 +66,7 @@ impl CharExt for char {
             unicode_blocks::CJK_COMPATIBILITY_IDEOGRAPHS_SUPPLEMENT,
             unicode_blocks::CJK_RADICALS_SUPPLEMENT,
             unicode_blocks::ENCLOSED_CJK_LETTERS_AND_MONTHS,
-            unicode_blocks::HIRAGANA
+            unicode_blocks::HIRAGANA,
         ];
 
         blocks.contains(&block)

--- a/harper-core/src/document.rs
+++ b/harper-core/src/document.rs
@@ -17,7 +17,7 @@ use crate::{Dictionary, FatToken, FullDictionary, Lrc, Token, TokenKind, TokenSt
 #[derive(Debug, Clone)]
 pub struct Document {
     source: Lrc<Vec<char>>,
-    tokens: Vec<Token>
+    tokens: Vec<Token>,
 }
 
 impl Default for Document {
@@ -48,7 +48,7 @@ impl Document {
     pub fn new_from_vec(
         source: Lrc<Vec<char>>,
         parser: &mut impl Parser,
-        dictionary: &impl Dictionary
+        dictionary: &impl Dictionary,
     ) -> Self {
         let tokens = parser.parse(&source);
 
@@ -153,7 +153,7 @@ impl Document {
             &old[indices
                 .last()
                 .map(|v| v + stretch_len)
-                .unwrap_or(indices.len())..]
+                .unwrap_or(indices.len())..],
         );
     }
 
@@ -304,7 +304,7 @@ impl Document {
     pub fn get_full_string(&self) -> String {
         self.get_span_content_str(Span {
             start: 0,
-            end: self.source.len()
+            end: self.source.len(),
         })
     }
 
@@ -642,7 +642,7 @@ fn is_chunk_terminator(token: &TokenKind) -> bool {
         TokenKind::Punctuation(punct) => {
             matches!(punct, Punctuation::Comma | Punctuation::Quote { .. })
         }
-        _ => false
+        _ => false,
     }
 }
 
@@ -651,11 +651,11 @@ fn is_sentence_terminator(token: &TokenKind) -> bool {
         TokenKind::Punctuation(punct) => [
             Punctuation::Period,
             Punctuation::Bang,
-            Punctuation::Question
+            Punctuation::Question,
         ]
         .contains(punct),
         TokenKind::ParagraphBreak => true,
-        _ => false
+        _ => false,
     }
 }
 
@@ -749,7 +749,7 @@ mod tests {
         assert_token_count("This is the 3rd test", 9);
         assert_token_count(
             "It works even with weird capitalization like this: 600nD",
-            18
+            18,
         );
     }
 

--- a/harper-core/src/language_detection.rs
+++ b/harper-core/src/language_detection.rs
@@ -18,7 +18,7 @@ pub fn is_likely_english(doc: &Document, dict: &impl Dictionary) -> bool {
                 }
             }
             TokenKind::Punctuation(_) => punctuation += 1,
-            _ => ()
+            _ => (),
         }
     }
 
@@ -62,7 +62,7 @@ mod tests {
     #[test]
     fn detects_french() {
         assert_not_english(
-            "C'est du français. Il ne devrait pas être marqué comme anglais par Harper."
+            "C'est du français. Il ne devrait pas être marqué comme anglais par Harper.",
         );
     }
 
@@ -100,7 +100,7 @@ def fibIter(n):
     for _ in range(2, n):
         fibPrev, fib = fib, fib + fibPrev
     return fib
-        "#
+        "#,
         );
     }
 }

--- a/harper-core/src/lexing/email_address.rs
+++ b/harper-core/src/lexing/email_address.rs
@@ -18,7 +18,7 @@ pub fn lex_email_address(source: &[char]) -> Option<FoundToken> {
 
     Some(FoundToken {
         next_index: at_loc + 1 + domain_part_len,
-        token: TokenKind::EmailAddress
+        token: TokenKind::EmailAddress,
     })
 }
 
@@ -90,7 +90,7 @@ fn valid_unquoted_character(c: char) -> bool {
 
     let others = [
         '!', '#', '$', '%', '&', '\'', '*', '+', '-', '/', '=', '?', '^', '_', '`', '{', '|', '}',
-        '~', '.'
+        '~', '.',
     ];
 
     if others.contains(&c) {
@@ -125,7 +125,7 @@ mod tests {
             r#"user-"#,
             r#"postmaster"#,
             r#"postmaster"#,
-            r#"_test"#
+            r#"_test"#,
         ]
         .into_iter()
         .map(|s| s.chars().collect())

--- a/harper-core/src/lexing/hostname.rs
+++ b/harper-core/src/lexing/hostname.rs
@@ -38,7 +38,7 @@ pub mod tests {
             r#"example.org"#,
             r#"strange.example.com"#,
             r#"example.org"#,
-            r#"example.org"#
+            r#"example.org"#,
         ]
         .into_iter()
         .map(|s| s.chars().collect())

--- a/harper-core/src/lexing/mod.rs
+++ b/harper-core/src/lexing/mod.rs
@@ -15,7 +15,7 @@ pub struct FoundToken {
     /// The index of the character __after__ the lexed token
     pub next_index: usize,
     /// Token lexed
-    pub token: TokenKind
+    pub token: TokenKind,
 }
 
 pub fn lex_token(source: &[char]) -> Option<FoundToken> {
@@ -28,7 +28,7 @@ pub fn lex_token(source: &[char]) -> Option<FoundToken> {
         lex_url,
         lex_email_address,
         lex_word,
-        lex_catch
+        lex_catch,
     ];
 
     for lexer in lexers {
@@ -51,7 +51,7 @@ fn lex_word(source: &[char]) -> Option<FoundToken> {
     } else {
         Some(FoundToken {
             next_index: end,
-            token: TokenKind::Word(WordMetadata::default())
+            token: TokenKind::Word(WordMetadata::default()),
         })
     }
 }
@@ -77,7 +77,7 @@ pub fn lex_number(source: &[char]) -> Option<FoundToken> {
         if let Ok(n) = s.parse::<f64>() {
             return Some(FoundToken {
                 token: TokenKind::Number(n.into(), None),
-                next_index: end + 1
+                next_index: end + 1,
             });
         }
     }
@@ -91,7 +91,7 @@ fn lex_newlines(source: &[char]) -> Option<FoundToken> {
     if count > 0 {
         Some(FoundToken {
             token: TokenKind::Newline(count),
-            next_index: count
+            next_index: count,
         })
     } else {
         None
@@ -104,7 +104,7 @@ fn lex_tabs(source: &[char]) -> Option<FoundToken> {
     if count > 0 {
         Some(FoundToken {
             token: TokenKind::Space(count * 2),
-            next_index: count
+            next_index: count,
         })
     } else {
         None
@@ -117,7 +117,7 @@ fn lex_spaces(source: &[char]) -> Option<FoundToken> {
     if count > 0 {
         Some(FoundToken {
             token: TokenKind::Space(count),
-            next_index: count
+            next_index: count,
         })
     } else {
         None
@@ -134,7 +134,7 @@ fn lex_punctuation(source: &[char]) -> Option<FoundToken> {
 
     Some(FoundToken {
         next_index: 1,
-        token: TokenKind::Punctuation(punct)
+        token: TokenKind::Punctuation(punct),
     })
 }
 
@@ -144,7 +144,7 @@ fn lex_quote(source: &[char]) -> Option<FoundToken> {
     if c == '\"' || c == '“' || c == '”' {
         Some(FoundToken {
             next_index: 1,
-            token: TokenKind::Punctuation(Punctuation::Quote(Quote { twin_loc: None }))
+            token: TokenKind::Punctuation(Punctuation::Quote(Quote { twin_loc: None })),
         })
     } else {
         None
@@ -155,7 +155,7 @@ fn lex_quote(source: &[char]) -> Option<FoundToken> {
 fn lex_catch(_source: &[char]) -> Option<FoundToken> {
     Some(FoundToken {
         next_index: 1,
-        token: TokenKind::Unlintable
+        token: TokenKind::Unlintable,
     })
 }
 

--- a/harper-core/src/lexing/url.rs
+++ b/harper-core/src/lexing/url.rs
@@ -14,7 +14,7 @@ pub fn lex_url(source: &[char]) -> Option<FoundToken> {
 
     Some(FoundToken {
         next_index: url_end + sep + 1,
-        token: TokenKind::Url
+        token: TokenKind::Url,
     })
 }
 
@@ -92,7 +92,7 @@ fn lex_hostport(source: &[char]) -> Option<usize> {
                     c.is_ascii_digit()
                 })
                 .map(|(i, _)| i)
-                .unwrap_or(source.len())
+                .unwrap_or(source.len()),
         )
     } else {
         Some(hostname_end)

--- a/harper-core/src/linting/an_a.rs
+++ b/harper-core/src/linting/an_a.rs
@@ -25,7 +25,7 @@ impl Linter for AnA {
             let is_a_an = match chars_first {
                 ['a'] => Some(true),
                 ['a', 'n'] => Some(false),
-                _ => None
+                _ => None,
             };
 
             let Some(a_an) = is_a_an else {
@@ -37,7 +37,7 @@ impl Linter for AnA {
             if a_an != should_be_a_an {
                 let replacement = match a_an {
                     true => vec!['a', 'n'],
-                    false => vec!['a']
+                    false => vec!['a'],
                 };
 
                 lints.push(Lint {
@@ -45,7 +45,7 @@ impl Linter for AnA {
                     lint_kind: LintKind::Miscellaneous,
                     suggestions: vec![Suggestion::ReplaceWith(replacement)],
                     message: "Incorrect indefinite article.".to_string(),
-                    priority: 31
+                    priority: 31,
                 })
             }
         }
@@ -59,7 +59,7 @@ fn to_lower_word(word: &[char]) -> Cow<'_, [char]> {
         Cow::Owned(
             word.iter()
                 .flat_map(|c| c.to_lowercase())
-                .collect::<Vec<_>>()
+                .collect::<Vec<_>>(),
         )
     } else {
         Cow::Borrowed(word)

--- a/harper-core/src/linting/avoid_curses.rs
+++ b/harper-core/src/linting/avoid_curses.rs
@@ -14,7 +14,7 @@ impl Linter for AvoidCurses {
                 lint_kind: LintKind::Miscellaneous,
                 suggestions: vec![],
                 message: "Try to avoid offensive language.".to_string(),
-                priority: 63
+                priority: 63,
             })
             .collect()
     }

--- a/harper-core/src/linting/ellipsis_length.rs
+++ b/harper-core/src/linting/ellipsis_length.rs
@@ -28,7 +28,7 @@ impl Linter for EllipsisLength {
                     lint_kind: LintKind::Formatting,
                     suggestions: vec![Suggestion::ReplaceWith(vec!['.', '.', '.'])],
                     message: "Horizontal ellipsis must have 3 dots.".to_string(),
-                    priority: 31
+                    priority: 31,
                 })
             }
         }

--- a/harper-core/src/linting/lint.rs
+++ b/harper-core/src/linting/lint.rs
@@ -13,7 +13,7 @@ pub struct Lint {
     pub message: String,
     /// A numerical value for the importance of a lint.
     /// Lower = more important.
-    pub priority: u8
+    pub priority: u8,
 }
 
 impl Default for Lint {
@@ -23,7 +23,7 @@ impl Default for Lint {
             lint_kind: Default::default(),
             suggestions: Default::default(),
             message: Default::default(),
-            priority: 127
+            priority: 127,
         }
     }
 }
@@ -36,7 +36,7 @@ pub enum LintKind {
     Repetition,
     Readability,
     #[default]
-    Miscellaneous
+    Miscellaneous,
 }
 
 impl Display for LintKind {
@@ -47,7 +47,7 @@ impl Display for LintKind {
             LintKind::Formatting => "Formatting",
             LintKind::Repetition => "Repetition",
             LintKind::Readability => "Readability",
-            LintKind::Miscellaneous => "Miscellaneous"
+            LintKind::Miscellaneous => "Miscellaneous",
         };
 
         write!(f, "{}", s)
@@ -57,7 +57,7 @@ impl Display for LintKind {
 #[derive(Debug, Clone, Serialize, Deserialize, Is)]
 pub enum Suggestion {
     ReplaceWith(Vec<char>),
-    Remove
+    Remove,
 }
 
 impl Display for Suggestion {
@@ -66,7 +66,7 @@ impl Display for Suggestion {
             Suggestion::ReplaceWith(with) => {
                 write!(f, "Replace with: “{}”", with.iter().collect::<String>())
             }
-            Suggestion::Remove => write!(f, "Remove error")
+            Suggestion::Remove => write!(f, "Remove error"),
         }
     }
 }

--- a/harper-core/src/linting/matcher.rs
+++ b/harper-core/src/linting/matcher.rs
@@ -7,7 +7,7 @@ struct PatternToken {
     /// The inner data of the [`TokenKind`] should be replaced with the default
     /// value.
     kind: TokenKind,
-    content: Option<CharString>
+    content: Option<CharString>,
 }
 
 impl PatternToken {
@@ -15,12 +15,12 @@ impl PatternToken {
         if token.kind.is_word() {
             Self {
                 kind: token.kind.with_default_data(),
-                content: Some(document.get_span_content(token.span).into())
+                content: Some(document.get_span_content(token.span).into()),
             }
         } else {
             Self {
                 kind: token.kind,
-                content: None
+                content: None,
             }
         }
     }
@@ -88,13 +88,13 @@ macro_rules! pt {
 
 struct Rule {
     pattern: Vec<PatternToken>,
-    replace_with: Vec<char>
+    replace_with: Vec<char>,
 }
 
 /// A linter that uses a variety of curated pattern matches to find and fix
 /// common grammatical issues.
 pub struct Matcher {
-    triggers: Vec<Rule>
+    triggers: Vec<Rule>,
 }
 
 impl Matcher {
@@ -280,18 +280,18 @@ impl Matcher {
         // We need to be more explicit that we are replacing with an Em dash
         triggers.push(Rule {
             pattern: vec![pt!(Hyphen), pt!(Hyphen), pt!(Hyphen)],
-            replace_with: vecword!("—")
+            replace_with: vecword!("—"),
         });
 
         // Same goes for this En dash
         triggers.push(Rule {
             pattern: vec![pt!(Hyphen), pt!(Hyphen)],
-            replace_with: vecword!("–")
+            replace_with: vecword!("–"),
         });
 
         triggers.push(Rule {
             pattern: vec![pt!("L"), pt!(Period), pt!("L"), pt!(Period), pt!("M")],
-            replace_with: vecword!("large language model")
+            replace_with: vecword!("large language model"),
         });
 
         triggers.push(Rule {
@@ -303,7 +303,7 @@ impl Matcher {
                 pt!("M"),
                 pt!(Period),
             ],
-            replace_with: vecword!("large language model")
+            replace_with: vecword!("large language model"),
         });
 
         Self { triggers }
@@ -343,7 +343,7 @@ impl Linter for Matcher {
                 if match_tokens.len() == trigger.pattern.len() && !match_tokens.is_empty() {
                     let span = Span::new(
                         match_tokens.first().unwrap().span.start,
-                        match_tokens.last().unwrap().span.end
+                        match_tokens.last().unwrap().span.end,
                     );
 
                     lints.push(Lint {
@@ -354,7 +354,7 @@ impl Linter for Matcher {
                             "Did you mean “{}”?",
                             trigger.replace_with.iter().collect::<String>()
                         ),
-                        priority: 15
+                        priority: 15,
                     })
                 }
             }

--- a/harper-core/src/linting/multiple_sequential_pronouns.rs
+++ b/harper-core/src/linting/multiple_sequential_pronouns.rs
@@ -9,13 +9,13 @@ use crate::{Lint, Lrc, Token, TokenStringExt};
 /// Linter that checks if multiple pronouns are being used right after each
 /// other. This is a common mistake to make during the revision process.
 pub struct MultipleSequentialPronouns {
-    pattern: Box<dyn Pattern>
+    pattern: Box<dyn Pattern>,
 }
 
 impl MultipleSequentialPronouns {
     fn new() -> Self {
         let pronouns: HashSet<_> = [
-            "me", "my", "I", "we", "you", "he", "him", "her", "she", "it", "they"
+            "me", "my", "I", "we", "you", "he", "him", "her", "she", "it", "they",
         ]
         .into_iter()
         .collect();
@@ -29,9 +29,9 @@ impl MultipleSequentialPronouns {
                     .then_one_or_more(Box::new(
                         SequencePattern::default()
                             .then_whitespace()
-                            .then_any_word_in(pronouns.clone())
-                    ))
-            )
+                            .then_any_word_in(pronouns.clone()),
+                    )),
+            ),
         }
     }
 }
@@ -46,10 +46,10 @@ impl PatternLinter for MultipleSequentialPronouns {
 
         if matched_tokens.len() == 3 {
             suggestions.push(Suggestion::ReplaceWith(
-                matched_tokens[0].span.get_content(source).to_vec()
+                matched_tokens[0].span.get_content(source).to_vec(),
             ));
             suggestions.push(Suggestion::ReplaceWith(
-                matched_tokens[2].span.get_content(source).to_vec()
+                matched_tokens[2].span.get_content(source).to_vec(),
             ));
         }
 
@@ -58,7 +58,7 @@ impl PatternLinter for MultipleSequentialPronouns {
             lint_kind: LintKind::Repetition,
             message: "There are too many personal pronouns in sequence here.".to_owned(),
             priority: 63,
-            suggestions
+            suggestions,
         }
     }
 }
@@ -79,7 +79,7 @@ mod tests {
         assert_lint_count(
             "...little bit about my I want to do.",
             MultipleSequentialPronouns::new(),
-            1
+            1,
         )
     }
 
@@ -88,7 +88,7 @@ mod tests {
         assert_lint_count(
             "...little bit about my I you want to do.",
             MultipleSequentialPronouns::new(),
-            1
+            1,
         )
     }
 
@@ -97,7 +97,7 @@ mod tests {
         assert_lint_count(
             "...little bit about I want to do.",
             MultipleSequentialPronouns::new(),
-            0
+            0,
         )
     }
 
@@ -106,7 +106,7 @@ mod tests {
         assert_lint_count(
             "...little bit about I want to do to me you.",
             MultipleSequentialPronouns::new(),
-            1
+            1,
         )
     }
 

--- a/harper-core/src/linting/number_suffix_capitalization.rs
+++ b/harper-core/src/linting/number_suffix_capitalization.rs
@@ -24,7 +24,7 @@ impl Linter for NumberSuffixCapitalization {
                     lint_kind: LintKind::Capitalization,
                     message: "This suffix should be lowercase".to_string(),
                     suggestions: vec![Suggestion::ReplaceWith(
-                        chars.iter().map(|c| c.to_ascii_lowercase()).collect()
+                        chars.iter().map(|c| c.to_ascii_lowercase()).collect(),
                     )],
                     ..Default::default()
                 })

--- a/harper-core/src/linting/pattern_linter.rs
+++ b/harper-core/src/linting/pattern_linter.rs
@@ -18,7 +18,7 @@ pub trait PatternLinter: Send + Sync {
 
 impl<L> Linter for L
 where
-    L: PatternLinter
+    L: PatternLinter,
 {
     fn lint(&mut self, document: &crate::Document) -> Vec<Lint> {
         let mut lints = Vec::new();

--- a/harper-core/src/linting/repeated_words.rs
+++ b/harper-core/src/linting/repeated_words.rs
@@ -3,7 +3,7 @@ use crate::patterns::{Pattern, SequencePattern, WordPatternGroup};
 use crate::token::{Token, TokenStringExt};
 
 pub struct RepeatedWords {
-    pattern: Box<dyn Pattern>
+    pattern: Box<dyn Pattern>,
 }
 
 impl RepeatedWords {
@@ -23,7 +23,7 @@ impl Default for RepeatedWords {
             "people", "into", "year", "your", "good", "some", "could", "them", "see", "other",
             "than", "then", "now", "look", "only", "come", "its", "over", "think", "also", "back",
             "after", "use", "two", "how", "our", "work", "first", "well", "way", "even", "new",
-            "want", "because", "any", "these", "give", "day", "most", "us", "are"
+            "want", "because", "any", "these", "give", "day", "most", "us", "are",
         ];
 
         let mut pattern = WordPatternGroup::default();
@@ -35,13 +35,13 @@ impl Default for RepeatedWords {
                     SequencePattern::default()
                         .then_exact_word(word)
                         .then_whitespace()
-                        .then_exact_word(word)
-                )
+                        .then_exact_word(word),
+                ),
             );
         }
 
         Self {
-            pattern: Box::new(pattern)
+            pattern: Box::new(pattern),
         }
     }
 }
@@ -56,7 +56,7 @@ impl PatternLinter for RepeatedWords {
             span: matched_tokens.span().unwrap(),
             lint_kind: LintKind::Repetition,
             suggestions: vec![Suggestion::ReplaceWith(
-                matched_tokens[0].span.get_content(source).to_vec()
+                matched_tokens[0].span.get_content(source).to_vec(),
             )],
             message: "Did you mean to repeat this word?".to_string(),
             ..Default::default()

--- a/harper-core/src/linting/sentence_capitalization.rs
+++ b/harper-core/src/linting/sentence_capitalization.rs
@@ -28,11 +28,11 @@ impl Linter for SentenceCapitalization {
                             span: first_word.span.with_len(1),
                             lint_kind: LintKind::Capitalization,
                             suggestions: vec![Suggestion::ReplaceWith(
-                                first_letter.to_uppercase().collect_vec()
+                                first_letter.to_uppercase().collect_vec(),
                             )],
                             priority: 31,
                             message: "This sentence does not start with a capital letter"
-                                .to_string()
+                                .to_string(),
                         })
                     }
                 }
@@ -63,7 +63,7 @@ mod tests {
         assert_lint_count(
             "i have complete conviction. she is guilty",
             SentenceCapitalization,
-            2
+            2,
         )
     }
 
@@ -72,7 +72,7 @@ mod tests {
         assert_lint_count(
             "53 is the length of the longest word.",
             SentenceCapitalization,
-            0
+            0,
         );
     }
 
@@ -81,7 +81,7 @@ mod tests {
         assert_lint_count(
             "[`misspelled_word`] is assumed to be quite small (n < 100). ",
             SentenceCapitalization,
-            0
+            0,
         )
     }
 
@@ -90,7 +90,7 @@ mod tests {
         assert_lint_count(
             "the linter should not be affected by `this` unlintable.",
             SentenceCapitalization,
-            1
+            1,
         )
     }
 }

--- a/harper-core/src/linting/sentence_capitalization.rs
+++ b/harper-core/src/linting/sentence_capitalization.rs
@@ -99,7 +99,7 @@ mod tests {
         assert_lint_count(
             "the linter should not be affected by... that ellipsis.",
             SentenceCapitalization,
-            1
+            1,
         )
     }
 }

--- a/harper-core/src/linting/spaces.rs
+++ b/harper-core/src/linting/spaces.rs
@@ -24,7 +24,7 @@ impl Linter for Spaces {
                             "There are {} spaces where there should be only one.",
                             count
                         ),
-                        priority: 15
+                        priority: 15,
                     })
                 }
             }
@@ -54,7 +54,7 @@ impl Linter for Spaces {
                     lint_kind: LintKind::Formatting,
                     suggestions: vec![Suggestion::Remove],
                     message: "Unnecessary space at the end of the sentence.".to_string(),
-                    priority: 63
+                    priority: 63,
                 })
             }
         }

--- a/harper-core/src/linting/spell_check.rs
+++ b/harper-core/src/linting/spell_check.rs
@@ -9,17 +9,17 @@ use crate::{CharString, Dictionary, TokenStringExt};
 
 pub struct SpellCheck<T>
 where
-    T: Dictionary
+    T: Dictionary,
 {
     dictionary: T,
-    word_cache: HashMap<CharString, Vec<CharString>>
+    word_cache: HashMap<CharString, Vec<CharString>>,
 }
 
 impl<T: Dictionary> SpellCheck<T> {
     pub fn new(dictionary: T) -> Self {
         Self {
             dictionary,
-            word_cache: HashMap::new()
+            word_cache: HashMap::new(),
         }
     }
 }
@@ -87,7 +87,7 @@ impl<T: Dictionary> Linter for SpellCheck<T> {
                     "Did you mean to spell “{}” this way?",
                     document.get_span_content_str(word.span)
                 ),
-                priority: 63
+                priority: 63,
             })
         }
 

--- a/harper-core/src/linting/spelled_numbers.rs
+++ b/harper-core/src/linting/spelled_numbers.rs
@@ -19,10 +19,10 @@ impl Linter for SpelledNumbers {
                     span: number_tok.span,
                     lint_kind: LintKind::Readability,
                     suggestions: vec![Suggestion::ReplaceWith(
-                        spell_out_number(number as u64).unwrap().chars().collect()
+                        spell_out_number(number as u64).unwrap().chars().collect(),
                     )],
                     message: "Try to spell out numbers less than a hundred.".to_string(),
-                    priority: 63
+                    priority: 63,
                 })
             }
         }

--- a/harper-core/src/linting/terminating_conjunctions.rs
+++ b/harper-core/src/linting/terminating_conjunctions.rs
@@ -3,7 +3,7 @@ use crate::patterns::{ConsumesRemainingPattern, Pattern, SequencePattern};
 use crate::{Lrc, TokenStringExt};
 
 pub struct TerminatingConjunctions {
-    pattern: Box<dyn Pattern>
+    pattern: Box<dyn Pattern>,
 }
 
 impl Default for TerminatingConjunctions {
@@ -39,13 +39,13 @@ impl Default for TerminatingConjunctions {
                             "or",
                             "nor",
                             "so",
-                            "and"
+                            "and",
                         ]
                         .into_iter()
-                        .collect()
+                        .collect(),
                     ))
-                    .then_comma()
-            )))
+                    .then_comma(),
+            ))),
         }
     }
 }
@@ -67,7 +67,7 @@ impl PatternLinter for TerminatingConjunctions {
                 "Subordinating conjunctions like “{word}” should not appear at the end of a \
                  clause."
             ),
-            priority: 63
+            priority: 63,
         }
     }
 }
@@ -82,7 +82,7 @@ mod tests {
         assert_lint_count(
             "More often than, we cannot foresee that of our community.",
             TerminatingConjunctions::default(),
-            1
+            1,
         )
     }
 

--- a/harper-core/src/linting/unclosed_quotes.rs
+++ b/harper-core/src/linting/unclosed_quotes.rs
@@ -18,7 +18,7 @@ impl Linter for UnclosedQuotes {
                     lint_kind: LintKind::Formatting,
                     suggestions: vec![],
                     message: "This quote has no termination.".to_string(),
-                    priority: 255
+                    priority: 255,
                 })
             }
         }

--- a/harper-core/src/mask/mod.rs
+++ b/harper-core/src/mask/mod.rs
@@ -17,7 +17,7 @@ pub struct Mask {
     // Right now, there aren't any use-cases where we can't treat this as a stack.
     //
     // Assumed that no elements overlap and exist in sorted order.
-    pub(self) allowed: Vec<Span>
+    pub(self) allowed: Vec<Span>,
 }
 
 impl Mask {
@@ -25,13 +25,13 @@ impl Mask {
     /// disallowed.
     pub fn new_blank() -> Self {
         Self {
-            allowed: Vec::new()
+            allowed: Vec::new(),
         }
     }
 
     pub fn iter_allowed<'a>(
         &'a self,
-        source: &'a [char]
+        source: &'a [char],
     ) -> impl Iterator<Item = (Span, &'a [char])> + '_ {
         self.allowed.iter().map(|s| (*s, s.get_content(source)))
     }

--- a/harper-core/src/parsers/markdown.rs
+++ b/harper-core/src/parsers/markdown.rs
@@ -127,7 +127,7 @@ impl Parser for Markdown {
         let md_parser = pulldown_cmark::Parser::new_ext(
             &source_str,
             pulldown_cmark::Options::all()
-                .difference(pulldown_cmark::Options::ENABLE_SMART_PUNCTUATION)
+                .difference(pulldown_cmark::Options::ENABLE_SMART_PUNCTUATION),
         );
 
         let mut tokens = Vec::new();

--- a/harper-core/src/parsers/markdown.rs
+++ b/harper-core/src/parsers/markdown.rs
@@ -146,19 +146,19 @@ impl Parser for Markdown {
                 pulldown_cmark::Event::SoftBreak => {
                     tokens.push(Token {
                         span: Span::new_with_len(traversed_chars, 1),
-                        kind: TokenKind::Newline(1)
+                        kind: TokenKind::Newline(1),
                     });
                 }
                 pulldown_cmark::Event::HardBreak => {
                     tokens.push(Token {
                         span: Span::new_with_len(traversed_chars, 1),
-                        kind: TokenKind::Newline(2)
+                        kind: TokenKind::Newline(2),
                     });
                 }
                 pulldown_cmark::Event::Start(pulldown_cmark::Tag::List(v)) => {
                     tokens.push(Token {
                         span: Span::new_with_len(traversed_chars, 0),
-                        kind: TokenKind::Newline(2)
+                        kind: TokenKind::Newline(2),
                     });
                     stack.push(pulldown_cmark::Tag::List(v));
                 }
@@ -169,7 +169,7 @@ impl Parser for Markdown {
                 | pulldown_cmark::Event::End(pulldown_cmark::TagEnd::TableCell) => {
                     tokens.push(Token {
                         span: Span::new_with_len(traversed_chars, 0),
-                        kind: TokenKind::Newline(2)
+                        kind: TokenKind::Newline(2),
                     });
                     stack.pop();
                 }
@@ -183,7 +183,7 @@ impl Parser for Markdown {
 
                     tokens.push(Token {
                         span: Span::new_with_len(traversed_chars, chunk_len),
-                        kind: TokenKind::Unlintable
+                        kind: TokenKind::Unlintable,
                     });
                 }
                 pulldown_cmark::Event::Text(text) => {
@@ -195,7 +195,7 @@ impl Parser for Markdown {
                         if matches!(tag, Tag::CodeBlock(..)) {
                             tokens.push(Token {
                                 span: Span::new_with_len(traversed_chars, text.chars().count()),
-                                kind: TokenKind::Unlintable
+                                kind: TokenKind::Unlintable,
                             });
                             continue;
                         }
@@ -222,7 +222,7 @@ impl Parser for Markdown {
 
                     tokens.append(&mut new_tokens);
                 }
-                _ => ()
+                _ => (),
             }
         }
 

--- a/harper-core/src/parsers/mask.rs
+++ b/harper-core/src/parsers/mask.rs
@@ -6,16 +6,16 @@ use crate::{Span, Token, TokenKind};
 pub struct Mask<M, P>
 where
     M: Masker,
-    P: Parser
+    P: Parser,
 {
     pub masker: M,
-    pub parser: P
+    pub parser: P,
 }
 
 impl<M, P> Mask<M, P>
 where
     M: Masker,
-    P: Parser
+    P: Parser,
 {
     pub fn new(masker: M, parser: P) -> Self {
         Self { masker, parser }
@@ -25,7 +25,7 @@ where
 impl<M, P> Parser for Mask<M, P>
 where
     M: Masker,
-    P: Parser
+    P: Parser,
 {
     fn parse(&mut self, source: &[char]) -> Vec<Token> {
         let mask = self.masker.create_mask(source);

--- a/harper-core/src/parsers/mod.rs
+++ b/harper-core/src/parsers/mod.rs
@@ -20,7 +20,7 @@ pub trait StrParser {
 
 impl<T> StrParser for T
 where
-    T: Parser
+    T: Parser,
 {
     fn parse_str(&mut self, source: impl AsRef<str>) -> Vec<Token> {
         let source: Vec<_> = source.as_ref().chars().collect();
@@ -37,7 +37,7 @@ mod tests {
     fn assert_tokens_eq(
         test_str: impl AsRef<str>,
         expected: &[TokenKind],
-        parser: &mut impl Parser
+        parser: &mut impl Parser,
     ) {
         let chars: Vec<_> = test_str.as_ref().chars().collect();
         let tokens = parser.parse(&chars);
@@ -74,8 +74,8 @@ mod tests {
                 Space(1),
                 TokenKind::blank_word(),
                 Space(1),
-                TokenKind::blank_word()
-            ]
+                TokenKind::blank_word(),
+            ],
         )
     }
 
@@ -91,8 +91,8 @@ mod tests {
                 Space(1),
                 TokenKind::blank_word(),
                 Space(1),
-                TokenKind::blank_word()
-            ]
+                TokenKind::blank_word(),
+            ],
         );
     }
 
@@ -108,8 +108,8 @@ mod tests {
                 Newline(2),
                 TokenKind::blank_word(),
                 Space(1),
-                TokenKind::blank_word()
-            ]
+                TokenKind::blank_word(),
+            ],
         );
     }
 

--- a/harper-core/src/parsers/plain_english.rs
+++ b/harper-core/src/parsers/plain_english.rs
@@ -23,7 +23,7 @@ impl Parser for PlainEnglish {
             if let Some(FoundToken { token, next_index }) = lex_token(&source[cursor..]) {
                 tokens.push(Token {
                     span: Span::new(cursor, cursor + next_index),
-                    kind: token
+                    kind: token,
                 });
                 cursor += next_index;
             } else {

--- a/harper-core/src/patterns/consumes_remaining_pattern.rs
+++ b/harper-core/src/patterns/consumes_remaining_pattern.rs
@@ -5,7 +5,7 @@ use crate::Token;
 /// If the wrapped pattern matches the remainder of the input, it returns the
 /// input's length. Otherwise, it matches nothing.
 pub struct ConsumesRemainingPattern {
-    inner: Box<dyn Pattern>
+    inner: Box<dyn Pattern>,
 }
 
 impl ConsumesRemainingPattern {

--- a/harper-core/src/patterns/mod.rs
+++ b/harper-core/src/patterns/mod.rs
@@ -37,7 +37,7 @@ pub trait PatternExt {
 
 impl<P> PatternExt for P
 where
-    P: Pattern
+    P: Pattern,
 {
     fn find_all_matches(&self, tokens: &[Token], source: &[char]) -> Vec<Span> {
         let mut found = Vec::new();
@@ -77,7 +77,7 @@ where
 impl<F> Pattern for F
 where
     F: Fn(&Token, &[char]) -> bool,
-    F: Send + Sync
+    F: Send + Sync,
 {
     fn matches(&self, tokens: &[Token], source: &[char]) -> usize {
         if tokens.is_empty() {
@@ -97,7 +97,7 @@ where
 #[cfg(not(feature = "concurrent"))]
 impl<F> Pattern for F
 where
-    F: Fn(&Token, &[char]) -> bool
+    F: Fn(&Token, &[char]) -> bool,
 {
     fn matches(&self, tokens: &[Token], source: &[char]) -> usize {
         if tokens.is_empty() {

--- a/harper-core/src/patterns/naive_pattern_group.rs
+++ b/harper-core/src/patterns/naive_pattern_group.rs
@@ -5,7 +5,7 @@ use crate::Token;
 /// returning the first one that matches..
 #[derive(Default)]
 pub struct NaivePatternGroup {
-    patterns: Vec<Box<dyn Pattern>>
+    patterns: Vec<Box<dyn Pattern>>,
 }
 
 impl NaivePatternGroup {

--- a/harper-core/src/patterns/repeating_pattern.rs
+++ b/harper-core/src/patterns/repeating_pattern.rs
@@ -5,7 +5,7 @@ use crate::Token;
 ///
 /// Somewhat reminiscent of the `.*` operator in Regex.
 pub struct RepeatingPattern {
-    inner: Box<dyn Pattern>
+    inner: Box<dyn Pattern>,
 }
 
 impl RepeatingPattern {
@@ -39,7 +39,7 @@ mod tests {
     #[test]
     fn matches_anything() {
         let doc = Document::new_plain_english_curated(
-            "This matcher will match the entirety of any document!"
+            "This matcher will match the entirety of any document!",
         );
         let pat = RepeatingPattern::new(Box::new(AnyPattern));
 

--- a/harper-core/src/patterns/sequence_pattern.rs
+++ b/harper-core/src/patterns/sequence_pattern.rs
@@ -8,7 +8,7 @@ use crate::{Lrc, Token, TokenKind};
 /// A pattern that checks that a sequence of others patterns match.
 #[derive(Default)]
 pub struct SequencePattern {
-    token_patterns: Vec<Box<dyn Pattern>>
+    token_patterns: Vec<Box<dyn Pattern>>,
 }
 
 macro_rules! gen_then_from_is {
@@ -164,7 +164,7 @@ mod tests {
         pronouns.insert("hers");
         let pronouns = Lrc::new(pronouns);
 
-        let mut pat = SequencePattern::default()
+        let pat = SequencePattern::default()
             .then_exact_word("it")
             .then_whitespace()
             .then_exact_word("was")

--- a/harper-core/src/patterns/token_kind_pattern_group.rs
+++ b/harper-core/src/patterns/token_kind_pattern_group.rs
@@ -5,7 +5,7 @@ use crate::{Token, TokenKind};
 
 pub struct TokenKindPatternGroup {
     /// These are patterns whose first token's kind must be strictly equal.
-    strict_patterns: HashMap<TokenKind, Box<dyn Pattern>>
+    strict_patterns: HashMap<TokenKind, Box<dyn Pattern>>,
 }
 
 impl Pattern for TokenKindPatternGroup {

--- a/harper-core/src/patterns/word_pattern_group.rs
+++ b/harper-core/src/patterns/word_pattern_group.rs
@@ -9,9 +9,9 @@ use crate::CharString;
 #[derive(Default)]
 pub struct WordPatternGroup<P>
 where
-    P: Pattern
+    P: Pattern,
 {
-    patterns: HashMap<CharString, P>
+    patterns: HashMap<CharString, P>,
 }
 
 impl WordPatternGroup<NaivePatternGroup> {
@@ -30,7 +30,7 @@ impl WordPatternGroup<NaivePatternGroup> {
 
 impl<P> Pattern for WordPatternGroup<P>
 where
-    P: Pattern
+    P: Pattern,
 {
     fn matches(&self, tokens: &[crate::Token], source: &[char]) -> usize {
         let Some(first) = tokens.first() else {

--- a/harper-core/src/punctuation.rs
+++ b/harper-core/src/punctuation.rs
@@ -74,7 +74,7 @@ pub enum Punctuation {
     /// `|`
     Pipe,
     /// `_`
-    Underscore
+    Underscore,
 }
 
 impl Punctuation {
@@ -114,7 +114,7 @@ impl Punctuation {
             '$' => Punctuation::Dollar,
             '|' => Punctuation::Pipe,
             '_' => Punctuation::Underscore,
-            _ => return None
+            _ => return None,
         };
 
         Some(punct)
@@ -124,5 +124,5 @@ impl Punctuation {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, PartialOrd, Hash)]
 pub struct Quote {
     /// The location of the matching quote, if it exists.
-    pub twin_loc: Option<usize>
+    pub twin_loc: Option<usize>,
 }

--- a/harper-core/src/span.rs
+++ b/harper-core/src/span.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq)]
 pub struct Span {
     pub start: usize,
-    pub end: usize
+    pub end: usize,
 }
 
 impl Span {
@@ -18,7 +18,7 @@ impl Span {
     pub fn new_with_len(start: usize, len: usize) -> Self {
         Self {
             start,
-            end: start + len
+            end: start + len,
         }
     }
 

--- a/harper-core/src/spell/full_dictionary.rs
+++ b/harper-core/src/spell/full_dictionary.rs
@@ -22,7 +22,7 @@ pub struct FullDictionary {
     /// that has a word whose index is that length.
     word_len_starts: Vec<usize>,
     /// All English words
-    word_map: HashMap<CharString, WordMetadata>
+    word_map: HashMap<CharString, WordMetadata>,
 }
 
 /// The uncached function that is used to produce the original copy of the
@@ -43,7 +43,7 @@ fn uncached_inner_new() -> Lrc<FullDictionary> {
     Lrc::new(FullDictionary {
         word_map,
         word_len_starts: FullDictionary::create_len_starts(&mut words),
-        words
+        words,
     })
 }
 
@@ -56,7 +56,7 @@ impl FullDictionary {
         Self {
             words: Vec::new(),
             word_len_starts: Vec::new(),
-            word_map: HashMap::new()
+            word_map: HashMap::new(),
         }
     }
 
@@ -71,7 +71,7 @@ impl FullDictionary {
     /// distinct calls to this function.
     pub fn extend_words(
         &mut self,
-        words: impl IntoIterator<Item = (impl AsRef<[char]>, WordMetadata)>
+        words: impl IntoIterator<Item = (impl AsRef<[char]>, WordMetadata)>,
     ) {
         let pairs: Vec<_> = words
             .into_iter()

--- a/harper-core/src/spell/hunspell/affix_replacement.rs
+++ b/harper-core/src/spell/hunspell/affix_replacement.rs
@@ -7,7 +7,7 @@ use super::Error;
 pub struct AffixReplacement {
     pub remove: Vec<char>,
     pub add: Vec<char>,
-    pub condition: Matcher
+    pub condition: Matcher,
 }
 
 impl AffixReplacement {
@@ -15,7 +15,7 @@ impl AffixReplacement {
         HumanReadableAffixReplacement {
             remove: self.remove.iter().collect(),
             add: self.add.iter().collect(),
-            condition: self.condition.to_string()
+            condition: self.condition.to_string(),
         }
     }
 }
@@ -26,7 +26,7 @@ impl AffixReplacement {
 pub struct HumanReadableAffixReplacement {
     pub remove: String,
     pub add: String,
-    pub condition: String
+    pub condition: String,
 }
 
 impl HumanReadableAffixReplacement {
@@ -34,7 +34,7 @@ impl HumanReadableAffixReplacement {
         Ok(AffixReplacement {
             remove: self.remove.chars().collect(),
             add: self.add.chars().collect(),
-            condition: Matcher::parse(&self.condition)?
+            condition: Matcher::parse(&self.condition)?,
         })
     }
 }

--- a/harper-core/src/spell/hunspell/attribute_list.rs
+++ b/harper-core/src/spell/hunspell/attribute_list.rs
@@ -11,7 +11,7 @@ use crate::{CharString, Span, WordMetadata};
 #[derive(Debug, Clone)]
 pub struct AttributeList {
     /// Key = Affix Flag
-    affixes: HashMap<char, Expansion>
+    affixes: HashMap<char, Expansion>,
 }
 
 impl AttributeList {
@@ -21,7 +21,7 @@ impl AttributeList {
                 .affixes
                 .into_iter()
                 .map(|(affix, exp)| (affix, exp.into_human_readable()))
-                .collect()
+                .collect(),
         }
     }
 
@@ -33,7 +33,7 @@ impl AttributeList {
     pub fn expand_marked_word(
         &self,
         word: MarkedWord,
-        dest: &mut HashMap<CharString, WordMetadata>
+        dest: &mut HashMap<CharString, WordMetadata>,
     ) {
         dest.reserve(word.attributes.len() + 1);
         let mut gifted_metadata = WordMetadata::default();
@@ -74,9 +74,9 @@ impl AttributeList {
                     self.expand_marked_word(
                         MarkedWord {
                             letters: new_word.clone(),
-                            attributes: opp_attr.clone()
+                            attributes: opp_attr.clone(),
                         },
-                        dest
+                        dest,
                     );
                     let t_metadata = dest.get_mut(&new_word).unwrap();
                     t_metadata.append(&metadata);
@@ -105,7 +105,7 @@ impl AttributeList {
     pub fn expand_marked_words(
         &self,
         words: impl IntoIterator<Item = MarkedWord>,
-        dest: &mut HashMap<CharString, WordMetadata>
+        dest: &mut HashMap<CharString, WordMetadata>,
     ) {
         for word in words {
             self.expand_marked_word(word, dest);
@@ -115,7 +115,7 @@ impl AttributeList {
     fn apply_replacement(
         replacement: &AffixReplacement,
         letters: &[char],
-        suffix: bool
+        suffix: bool,
     ) -> Option<CharString> {
         if replacement.condition.len() > letters.len() {
             return None;
@@ -170,7 +170,7 @@ impl AttributeList {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HumanReadableAttributeList {
-    affixes: HashMap<char, HumanReadableExpansion>
+    affixes: HashMap<char, HumanReadableExpansion>,
 }
 
 impl HumanReadableAttributeList {

--- a/harper-core/src/spell/hunspell/error.rs
+++ b/harper-core/src/spell/hunspell/error.rs
@@ -13,5 +13,5 @@ pub enum Error {
     #[error("Could not parse because we encountered the end of the line.")]
     UnexpectedEndOfLine,
     #[error("An error occured with a condition: {0}")]
-    Matcher(#[from] matcher::Error)
+    Matcher(#[from] matcher::Error),
 }

--- a/harper-core/src/spell/hunspell/expansion.rs
+++ b/harper-core/src/spell/hunspell/expansion.rs
@@ -15,7 +15,7 @@ pub struct Expansion {
     pub adds_metadata: WordMetadata,
     /// When the expansion is applied, the __parent__ word will have this
     /// metadata appended to it.
-    pub gifts_metadata: WordMetadata
+    pub gifts_metadata: WordMetadata,
 }
 
 impl Expansion {
@@ -29,7 +29,7 @@ impl Expansion {
                 .map(AffixReplacement::to_human_readable)
                 .collect(),
             adds_metadata: self.adds_metadata,
-            gifts_metadata: self.gifts_metadata
+            gifts_metadata: self.gifts_metadata,
         }
     }
 }
@@ -40,7 +40,7 @@ pub struct HumanReadableExpansion {
     pub cross_product: bool,
     pub replacements: Vec<HumanReadableAffixReplacement>,
     pub adds_metadata: WordMetadata,
-    pub gifts_metadata: WordMetadata
+    pub gifts_metadata: WordMetadata,
 }
 
 impl HumanReadableExpansion {
@@ -56,7 +56,7 @@ impl HumanReadableExpansion {
             cross_product: self.cross_product,
             replacements,
             adds_metadata: self.adds_metadata,
-            gifts_metadata: self.gifts_metadata
+            gifts_metadata: self.gifts_metadata,
         })
     }
 }

--- a/harper-core/src/spell/hunspell/matcher.rs
+++ b/harper-core/src/spell/hunspell/matcher.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Matcher {
     /// Position-based operators.
-    operators: Vec<Operator>
+    operators: Vec<Operator>,
 }
 
 impl Matcher {
@@ -42,7 +42,7 @@ impl Matcher {
                     }
                 }
                 '.' => operators.push(Operator::Any),
-                _ => operators.push(Operator::Literal(c))
+                _ => operators.push(Operator::Literal(c)),
             }
 
             char_idx += 1;
@@ -93,7 +93,7 @@ impl Display for Matcher {
 
                     write!(f, "]")?;
                 }
-                Operator::Any => write!(f, ".")?
+                Operator::Any => write!(f, ".")?,
             }
         }
 
@@ -106,7 +106,7 @@ enum Operator {
     Literal(char),
     MatchOne(Vec<char>),
     MatchNone(Vec<char>),
-    Any
+    Any,
 }
 
 impl Operator {
@@ -115,7 +115,7 @@ impl Operator {
             Operator::Literal(b) => a == *b,
             Operator::MatchOne(b) => b.contains(&a),
             Operator::MatchNone(b) => !b.contains(&a),
-            Operator::Any => true
+            Operator::Any => true,
         }
     }
 }
@@ -123,7 +123,7 @@ impl Operator {
 #[derive(Debug, Clone, Copy, thiserror::Error)]
 pub enum Error {
     #[error("Unmatched bracket at index: {index}")]
-    UnmatchedBracket { index: usize }
+    UnmatchedBracket { index: usize },
 }
 
 #[cfg(test)]

--- a/harper-core/src/spell/hunspell/word_list.rs
+++ b/harper-core/src/spell/hunspell/word_list.rs
@@ -4,7 +4,7 @@ use crate::CharString;
 #[derive(Debug, Clone)]
 pub struct MarkedWord {
     pub letters: CharString,
-    pub attributes: Vec<char>
+    pub attributes: Vec<char>,
 }
 
 /// Parse a Hunspell word list
@@ -25,12 +25,12 @@ pub fn parse_word_list(source: &str) -> Result<Vec<MarkedWord>, Error> {
         if let Some((word, attributes)) = line.split_once('/') {
             words.push(MarkedWord {
                 letters: word.chars().collect(),
-                attributes: attributes.chars().collect()
+                attributes: attributes.chars().collect(),
             })
         } else {
             words.push(MarkedWord {
                 letters: line.chars().collect(),
-                attributes: Vec::new()
+                attributes: Vec::new(),
             })
         }
     }

--- a/harper-core/src/spell/merged_dictionary.rs
+++ b/harper-core/src/spell/merged_dictionary.rs
@@ -10,20 +10,20 @@ use crate::{CharString, WordMetadata};
 #[derive(Clone, PartialEq)]
 pub struct MergedDictionary<T>
 where
-    T: Dictionary + Clone
+    T: Dictionary + Clone,
 {
     children: Vec<Arc<T>>,
-    merged: HashMap<CharString, WordMetadata>
+    merged: HashMap<CharString, WordMetadata>,
 }
 
 impl<T> MergedDictionary<T>
 where
-    T: Dictionary + Clone
+    T: Dictionary + Clone,
 {
     pub fn new() -> Self {
         Self {
             children: Vec::new(),
-            merged: HashMap::new()
+            merged: HashMap::new(),
         }
     }
 
@@ -34,7 +34,7 @@ where
 
 impl<T> Default for MergedDictionary<T>
 where
-    T: Dictionary + Clone
+    T: Dictionary + Clone,
 {
     fn default() -> Self {
         Self::new()
@@ -43,7 +43,7 @@ where
 
 impl<T> Dictionary for MergedDictionary<T>
 where
-    T: Dictionary + Clone
+    T: Dictionary + Clone,
 {
     fn contains_word(&self, word: &[char]) -> bool {
         for child in &self.children {
@@ -71,7 +71,7 @@ where
         Box::new(
             self.children
                 .iter()
-                .flat_map(move |c| c.words_with_len_iter(len))
+                .flat_map(move |c| c.words_with_len_iter(len)),
         )
     }
 

--- a/harper-core/src/spell/mod.rs
+++ b/harper-core/src/spell/mod.rs
@@ -19,7 +19,7 @@ pub fn suggest_correct_spelling<'a>(
     misspelled_word: &[char],
     result_limit: usize,
     max_edit_dist: u8,
-    dictionary: &'a impl Dictionary
+    dictionary: &'a impl Dictionary,
 ) -> Vec<&'a [char]> {
     let misspelled_word = seq_to_normalized(misspelled_word);
 
@@ -87,7 +87,7 @@ pub fn suggest_correct_spelling<'a>(
                 .into_iter()
                 .enumerate()
                 .filter(|(i, _)| *i != a && *i != b)
-                .map(|v| v.1 .0)
+                .map(|v| v.1 .0),
         );
     } else {
         // Push the rest
@@ -108,7 +108,7 @@ pub fn suggest_correct_spelling_str(
     misspelled_word: impl AsRef<str>,
     result_limit: usize,
     max_edit_dist: u8,
-    dictionary: &FullDictionary
+    dictionary: &FullDictionary,
 ) -> Vec<String> {
     let chars: Vec<char> = misspelled_word.as_ref().chars().collect();
 
@@ -127,7 +127,7 @@ fn edit_distance_min_alloc(
     source: &[char],
     target: &[char],
     previous_row: &mut Vec<u8>,
-    current_row: &mut Vec<u8>
+    current_row: &mut Vec<u8>,
 ) -> u8 {
     if cfg!(debug_assertions) {
         assert!(source.len() <= 255 && target.len() <= 255);
@@ -175,7 +175,7 @@ fn seq_to_normalized(seq: &[char]) -> Cow<'_, [char]> {
 fn char_to_normalized(c: char) -> char {
     match c {
         '’' => '\'',
-        _ => c
+        _ => c,
     }
 }
 

--- a/harper-core/src/token.rs
+++ b/harper-core/src/token.rs
@@ -12,7 +12,7 @@ use crate::{Quote, WordMetadata};
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Default)]
 pub struct Token {
     pub span: Span,
-    pub kind: TokenKind
+    pub kind: TokenKind,
 }
 
 impl Token {
@@ -26,7 +26,7 @@ impl Token {
 
         FatToken {
             content,
-            kind: self.kind
+            kind: self.kind,
         }
     }
 }
@@ -36,7 +36,7 @@ impl Token {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, PartialOrd)]
 pub struct FatToken {
     pub content: Vec<char>,
-    pub kind: TokenKind
+    pub kind: TokenKind,
 }
 
 #[derive(
@@ -58,7 +58,7 @@ pub enum TokenKind {
     /// ignored by all linters.
     #[default]
     Unlintable,
-    ParagraphBreak
+    ParagraphBreak,
 }
 
 impl TokenKind {
@@ -127,7 +127,7 @@ impl TokenKind {
             TokenKind::Number(..) => TokenKind::Number(Default::default(), Default::default()),
             TokenKind::Space(_) => TokenKind::Space(Default::default()),
             TokenKind::Newline(_) => TokenKind::Newline(Default::default()),
-            _ => *self
+            _ => *self,
         }
     }
 }
@@ -147,7 +147,7 @@ pub enum NumberSuffix {
     Th,
     St,
     Nd,
-    Rd
+    Rd,
 }
 
 impl NumberSuffix {
@@ -175,7 +175,7 @@ impl NumberSuffix {
             7 => Some(Self::Th),
             8 => Some(Self::Th),
             9 => Some(Self::Th),
-            _ => None
+            _ => None,
         }
     }
 
@@ -184,7 +184,7 @@ impl NumberSuffix {
             NumberSuffix::Th => vec!['t', 'h'],
             NumberSuffix::St => vec!['s', 't'],
             NumberSuffix::Nd => vec!['n', 'd'],
-            NumberSuffix::Rd => vec!['r', 'd']
+            NumberSuffix::Rd => vec!['r', 'd'],
         }
     }
 
@@ -212,7 +212,7 @@ impl NumberSuffix {
             ('R', 'd') => Some(NumberSuffix::Rd),
             ('r', 'D') => Some(NumberSuffix::Rd),
             ('R', 'D') => Some(NumberSuffix::Rd),
-            _ => None
+            _ => None,
         }
     }
 }

--- a/harper-core/src/word_metadata.rs
+++ b/harper-core/src/word_metadata.rs
@@ -8,7 +8,7 @@ pub struct WordMetadata {
     pub adjective: Option<AdjectiveData>,
     pub adverb: Option<AdverbData>,
     pub conjunction: Option<ConjunctionData>,
-    pub swear: Option<bool>
+    pub swear: Option<bool>,
 }
 
 impl WordMetadata {
@@ -20,7 +20,7 @@ impl WordMetadata {
                     (Some(a), Some(b)) => Some(a.or(&b)),
                     (Some(a), None) => Some(a),
                     (None, Some(b)) => Some(b),
-                    (None, None) => None
+                    (None, None) => None,
                 }
             };
         }
@@ -31,7 +31,7 @@ impl WordMetadata {
             adjective: merge!(self.adjective, other.adjective),
             adverb: merge!(self.adverb, other.adverb),
             conjunction: merge!(self.conjunction, other.conjunction),
-            swear: self.swear.or(other.swear)
+            swear: self.swear.or(other.swear),
         }
     }
 
@@ -121,13 +121,13 @@ impl WordMetadata {
 pub enum Tense {
     Past,
     Present,
-    Future
+    Future,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, PartialOrd, Eq, Hash)]
 pub struct VerbData {
     pub is_linking: Option<bool>,
-    pub tense: Option<Tense>
+    pub tense: Option<Tense>,
 }
 
 impl VerbData {
@@ -135,7 +135,7 @@ impl VerbData {
     pub fn or(&self, other: &Self) -> Self {
         Self {
             is_linking: self.is_linking.or(other.is_linking),
-            tense: self.tense.or(other.tense)
+            tense: self.tense.or(other.tense),
         }
     }
 }
@@ -145,7 +145,7 @@ pub struct NounData {
     pub is_proper: Option<bool>,
     pub is_plural: Option<bool>,
     pub is_possessive: Option<bool>,
-    pub is_pronoun: Option<bool>
+    pub is_pronoun: Option<bool>,
 }
 
 impl NounData {
@@ -155,7 +155,7 @@ impl NounData {
             is_proper: self.is_proper.or(other.is_proper),
             is_plural: self.is_plural.or(other.is_plural),
             is_possessive: self.is_possessive.or(other.is_possessive),
-            is_pronoun: self.is_pronoun.or(other.is_pronoun)
+            is_pronoun: self.is_pronoun.or(other.is_pronoun),
         }
     }
 }

--- a/harper-core/src/word_metadata.rs
+++ b/harper-core/src/word_metadata.rs
@@ -11,7 +11,7 @@ pub struct WordMetadata {
     pub swear: Option<bool>,
     /// Whether the word is considered especially common.
     #[serde(default = "default_common")]
-    pub common: bool
+    pub common: bool,
 }
 
 fn default_common() -> bool {
@@ -39,7 +39,7 @@ impl WordMetadata {
             adverb: merge!(self.adverb, other.adverb),
             conjunction: merge!(self.conjunction, other.conjunction),
             swear: self.swear.or(other.swear),
-            common: self.common || other.common
+            common: self.common || other.common,
         }
     }
 

--- a/harper-html/src/lib.rs
+++ b/harper-html/src/lib.rs
@@ -4,7 +4,7 @@ use harper_tree_sitter::TreeSitterMasker;
 use tree_sitter::Node;
 
 pub struct HtmlParser {
-    inner: parsers::Mask<TreeSitterMasker, PlainEnglish>
+    inner: parsers::Mask<TreeSitterMasker, PlainEnglish>,
 }
 
 impl HtmlParser {
@@ -18,8 +18,8 @@ impl Default for HtmlParser {
         Self {
             inner: parsers::Mask::new(
                 TreeSitterMasker::new(tree_sitter_html::language(), Self::node_condition),
-                PlainEnglish
-            )
+                PlainEnglish,
+            ),
         }
     }
 }

--- a/harper-ls/src/backend.rs
+++ b/harper-ls/src/backend.rs
@@ -7,13 +7,7 @@ use harper_comments::CommentParser;
 use harper_core::linting::{LintGroup, Linter};
 use harper_core::parsers::{Markdown, PlainEnglish};
 use harper_core::{
-    Dictionary,
-    Document,
-    FullDictionary,
-    MergedDictionary,
-    Token,
-    TokenKind,
-    WordMetadata
+    Dictionary, Document, FullDictionary, MergedDictionary, Token, TokenKind, WordMetadata,
 };
 use harper_html::HtmlParser;
 use serde_json::Value;
@@ -21,32 +15,13 @@ use tokio::sync::{Mutex, RwLock};
 use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::notification::PublishDiagnostics;
 use tower_lsp::lsp_types::{
-    CodeActionOrCommand,
-    CodeActionParams,
-    CodeActionProviderCapability,
-    CodeActionResponse,
-    Command,
-    ConfigurationItem,
-    Diagnostic,
-    DidChangeConfigurationParams,
-    DidChangeTextDocumentParams,
-    DidCloseTextDocumentParams,
-    DidOpenTextDocumentParams,
-    DidSaveTextDocumentParams,
-    ExecuteCommandOptions,
-    ExecuteCommandParams,
-    InitializeParams,
-    InitializeResult,
-    InitializedParams,
-    MessageType,
-    PublishDiagnosticsParams,
-    Range,
-    ServerCapabilities,
-    TextDocumentSyncCapability,
-    TextDocumentSyncKind,
-    TextDocumentSyncOptions,
-    TextDocumentSyncSaveOptions,
-    Url
+    CodeActionOrCommand, CodeActionParams, CodeActionProviderCapability, CodeActionResponse,
+    Command, ConfigurationItem, Diagnostic, DidChangeConfigurationParams,
+    DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
+    DidSaveTextDocumentParams, ExecuteCommandOptions, ExecuteCommandParams, InitializeParams,
+    InitializeResult, InitializedParams, MessageType, PublishDiagnosticsParams, Range,
+    ServerCapabilities, TextDocumentSyncCapability, TextDocumentSyncKind, TextDocumentSyncOptions,
+    TextDocumentSyncSaveOptions, Url,
 };
 use tower_lsp::{Client, LanguageServer};
 use tracing::{error, info};
@@ -61,7 +36,7 @@ use crate::pos_conv::range_to_span;
 pub struct Backend {
     client: Client,
     config: RwLock<Config>,
-    doc_state: Mutex<HashMap<Url, DocumentState>>
+    doc_state: Mutex<HashMap<Url, DocumentState>>,
 }
 
 impl Backend {
@@ -69,7 +44,7 @@ impl Backend {
         Self {
             client,
             doc_state: Mutex::new(HashMap::new()),
-            config: RwLock::new(config)
+            config: RwLock::new(config),
         }
     }
 
@@ -100,7 +75,7 @@ impl Backend {
     async fn load_file_dictionary(&self, url: &Url) -> Option<FullDictionary> {
         match load_dict(self.get_file_dict_path(url).await?).await {
             Ok(dict) => Some(dict),
-            Err(_err) => Some(FullDictionary::new())
+            Err(_err) => Some(FullDictionary::new()),
         }
     }
 
@@ -109,7 +84,7 @@ impl Backend {
             self.get_file_dict_path(url)
                 .await
                 .ok_or(anyhow!("Could not compute dictionary path."))?,
-            dict
+            dict,
         )
         .await?)
     }
@@ -119,7 +94,7 @@ impl Backend {
 
         match load_dict(&config.user_dict_path).await {
             Ok(dict) => dict,
-            Err(_err) => FullDictionary::new()
+            Err(_err) => FullDictionary::new(),
         }
     }
 
@@ -139,7 +114,7 @@ impl Backend {
 
     async fn generate_file_dictionary(
         &self,
-        url: &Url
+        url: &Url,
     ) -> anyhow::Result<MergedDictionary<FullDictionary>> {
         let (global_dictionary, file_dictionary) = tokio::join!(
             self.generate_global_dictionary(),
@@ -159,11 +134,11 @@ impl Backend {
     async fn update_document_from_file(
         &self,
         url: &Url,
-        language_id: Option<&str>
+        language_id: Option<&str>,
     ) -> anyhow::Result<()> {
         let content = match tokio::fs::read_to_string(
             url.to_file_path()
-                .map_err(|_| anyhow::format_err!("Could not extract file path."))?
+                .map_err(|_| anyhow::format_err!("Could not extract file path."))?,
         )
         .await
         {
@@ -181,7 +156,7 @@ impl Backend {
         &self,
         url: &Url,
         text: &str,
-        language_id: Option<&str>
+        language_id: Option<&str>,
     ) -> anyhow::Result<()> {
         self.pull_config().await;
 
@@ -246,7 +221,7 @@ impl Backend {
     async fn generate_code_actions(
         &self,
         url: &Url,
-        range: Range
+        range: Range,
     ) -> Result<Vec<CodeActionOrCommand>> {
         let (config, mut doc_states) = tokio::join!(self.config.read(), self.doc_state.lock());
         let Some(doc_state) = doc_states.get_mut(url) else {
@@ -278,7 +253,7 @@ impl Backend {
             actions.push(CodeActionOrCommand::Command(Command::new(
                 "Open URL".to_string(),
                 "HarperOpen".to_string(),
-                Some(vec![doc_state.document.get_span_content_str(span).into()])
+                Some(vec![doc_state.document.get_span_content_str(span).into()]),
             )))
         }
 
@@ -297,7 +272,7 @@ impl Backend {
         lints_to_diagnostics(
             doc_state.document.get_full_content(),
             &lints,
-            config.diagnostic_severity
+            config.diagnostic_severity,
         )
     }
 
@@ -307,7 +282,7 @@ impl Backend {
         let result = PublishDiagnosticsParams {
             uri: url.clone(),
             diagnostics,
-            version: None
+            version: None,
         };
 
         self.client
@@ -337,7 +312,7 @@ impl Backend {
             .client
             .configuration(vec![ConfigurationItem {
                 scope_uri: None,
-                section: None
+                section: None,
             }])
             .await
             .unwrap();
@@ -369,11 +344,11 @@ impl LanguageServer for Backend {
                         change: Some(TextDocumentSyncKind::FULL),
                         will_save: None,
                         will_save_wait_until: None,
-                        save: Some(TextDocumentSyncSaveOptions::Supported(true))
-                    }
+                        save: Some(TextDocumentSyncSaveOptions::Supported(true)),
+                    },
                 )),
                 ..Default::default()
-            }
+            },
         })
     }
 
@@ -402,7 +377,7 @@ impl LanguageServer for Backend {
             .update_document(
                 &params.text_document.uri,
                 &params.text_document.text,
-                Some(&params.text_document.language_id)
+                Some(&params.text_document.language_id),
             )
             .await;
 
@@ -484,7 +459,7 @@ impl LanguageServer for Backend {
                     error!("Unable to open URL: {}", err);
                 }
             },
-            _ => ()
+            _ => (),
         }
 
         Ok(None)

--- a/harper-ls/src/config.rs
+++ b/harper-ls/src/config.rs
@@ -12,7 +12,7 @@ pub enum DiagnosticSeverity {
     Error,
     Warning,
     Information,
-    Hint
+    Hint,
 }
 
 impl DiagnosticSeverity {
@@ -24,7 +24,7 @@ impl DiagnosticSeverity {
             DiagnosticSeverity::Information => {
                 tower_lsp::lsp_types::DiagnosticSeverity::INFORMATION
             }
-            DiagnosticSeverity::Hint => tower_lsp::lsp_types::DiagnosticSeverity::HINT
+            DiagnosticSeverity::Hint => tower_lsp::lsp_types::DiagnosticSeverity::HINT,
         }
     }
 }
@@ -38,7 +38,7 @@ pub struct CodeActionConfig {
     ///
     /// For example, we always want to allow users to add "misspelled" elements
     /// to dictionary, regardless of the spelling suggestions.
-    pub force_stable: bool
+    pub force_stable: bool,
 }
 
 impl CodeActionConfig {
@@ -68,7 +68,7 @@ pub struct Config {
     pub file_dict_path: PathBuf,
     pub lint_config: LintGroupConfig,
     pub diagnostic_severity: DiagnosticSeverity,
-    pub code_action_config: CodeActionConfig
+    pub code_action_config: CodeActionConfig,
 }
 
 impl Config {
@@ -126,7 +126,7 @@ impl Default for Config {
                 .join("harper-ls/file_dictionaries/"),
             lint_config: LintGroupConfig::default(),
             diagnostic_severity: DiagnosticSeverity::Hint,
-            code_action_config: CodeActionConfig::default()
+            code_action_config: CodeActionConfig::default(),
         }
     }
 }

--- a/harper-ls/src/diagnostics.rs
+++ b/harper-ls/src/diagnostics.rs
@@ -2,14 +2,8 @@ use std::collections::HashMap;
 
 use harper_core::linting::{Lint, Suggestion};
 use tower_lsp::lsp_types::{
-    CodeAction,
-    CodeActionKind,
-    CodeActionOrCommand,
-    Command,
-    Diagnostic,
-    TextEdit,
-    Url,
-    WorkspaceEdit
+    CodeAction, CodeActionKind, CodeActionOrCommand, Command, Diagnostic, TextEdit, Url,
+    WorkspaceEdit,
 };
 
 use crate::config::{CodeActionConfig, DiagnosticSeverity};
@@ -18,7 +12,7 @@ use crate::pos_conv::span_to_range;
 pub fn lints_to_diagnostics(
     source: &[char],
     lints: &[Lint],
-    severity: DiagnosticSeverity
+    severity: DiagnosticSeverity,
 ) -> Vec<Diagnostic> {
     lints
         .iter()
@@ -30,7 +24,7 @@ pub fn lint_to_code_actions<'a>(
     lint: &'a Lint,
     url: &'a Url,
     source: &'a [char],
-    config: &CodeActionConfig
+    config: &CodeActionConfig,
 ) -> Vec<CodeActionOrCommand> {
     let mut results = Vec::new();
 
@@ -42,7 +36,7 @@ pub fn lint_to_code_actions<'a>(
 
                 let replace_string = match suggestion {
                     Suggestion::ReplaceWith(with) => with.iter().collect(),
-                    Suggestion::Remove => "".to_string()
+                    Suggestion::Remove => "".to_string(),
                 };
 
                 Some(CodeAction {
@@ -54,19 +48,19 @@ pub fn lint_to_code_actions<'a>(
                             url.clone(),
                             vec![TextEdit {
                                 range,
-                                new_text: replace_string
-                            }]
+                                new_text: replace_string,
+                            }],
                         )])),
                         document_changes: None,
-                        change_annotations: None
+                        change_annotations: None,
                     }),
                     command: None,
                     is_preferred: None,
                     disabled: None,
-                    data: None
+                    data: None,
                 })
             })
-            .map(CodeActionOrCommand::CodeAction)
+            .map(CodeActionOrCommand::CodeAction),
     );
 
     if lint.lint_kind.is_spelling() {
@@ -75,13 +69,13 @@ pub fn lint_to_code_actions<'a>(
         results.push(CodeActionOrCommand::Command(Command::new(
             format!("Add \"{}\" to the global dictionary.", orig),
             "HarperAddToUserDict".to_string(),
-            Some(vec![orig.clone().into(), url.to_string().into()])
+            Some(vec![orig.clone().into(), url.to_string().into()]),
         )));
 
         results.push(CodeActionOrCommand::Command(Command::new(
             format!("Add \"{}\" to the file dictionary.", orig),
             "HarperAddToFileDict".to_string(),
-            Some(vec![orig.into(), url.to_string().into()])
+            Some(vec![orig.into(), url.to_string().into()]),
         )));
 
         if config.force_stable {
@@ -104,6 +98,6 @@ fn lint_to_diagnostic(lint: &Lint, source: &[char], severity: DiagnosticSeverity
         message: lint.message.clone(),
         related_information: None,
         tags: None,
-        data: None
+        data: None,
     }
 }

--- a/harper-ls/src/dictionary_io.rs
+++ b/harper-ls/src/dictionary_io.rs
@@ -52,7 +52,7 @@ async fn dict_from_word_list(mut r: impl AsyncRead + Unpin) -> io::Result<FullDi
     let mut dict = FullDictionary::new();
     dict.extend_words(
         str.lines()
-            .map(|l| (l.chars().collect::<Vec<char>>(), WordMetadata::default()))
+            .map(|l| (l.chars().collect::<Vec<char>>(), WordMetadata::default())),
     );
 
     Ok(dict)

--- a/harper-ls/src/document_state.rs
+++ b/harper-ls/src/document_state.rs
@@ -7,5 +7,5 @@ pub struct DocumentState {
     pub ident_dict: Lrc<FullDictionary>,
     pub dict: Lrc<MergedDictionary<FullDictionary>>,
     pub linter: LintGroup<Lrc<MergedDictionary<FullDictionary>>>,
-    pub language_id: Option<String>
+    pub language_id: Option<String>,
 }

--- a/harper-ls/src/main.rs
+++ b/harper-ls/src/main.rs
@@ -28,7 +28,7 @@ static DEFAULT_ADDRESS: &str = "127.0.0.1:4000";
 struct Args {
     /// Set to listen on standard input / output rather than TCP.
     #[arg(short, long, default_value_t = false)]
-    stdio: bool
+    stdio: bool,
 }
 
 #[tokio::main]

--- a/harper-ls/src/pos_conv.rs
+++ b/harper-ls/src/pos_conv.rs
@@ -30,7 +30,7 @@ fn index_to_position(source: &[char], index: usize) -> Position {
 
     Position {
         line: lines as u32,
-        character: cols as u32
+        character: cols as u32,
     }
 }
 
@@ -78,7 +78,7 @@ mod tests {
 
         let start = Position {
             line: 0,
-            character: 4
+            character: 4,
         };
 
         let i = position_to_index(&source, start);
@@ -98,7 +98,7 @@ mod tests {
 
         let a = Position {
             line: 1,
-            character: 2
+            character: 2,
         };
 
         let b = position_to_index(&source, a);

--- a/harper-tree-sitter/src/lib.rs
+++ b/harper-tree-sitter/src/lib.rs
@@ -7,14 +7,14 @@ use tree_sitter::{Language, Node, Tree, TreeCursor};
 /// allowing you to selectively parse only specific tree-sitter nodes.
 pub struct TreeSitterMasker {
     language: Language,
-    node_condition: fn(&Node) -> bool
+    node_condition: fn(&Node) -> bool,
 }
 
 impl TreeSitterMasker {
     pub fn new(language: Language, node_condition: fn(&Node) -> bool) -> Self {
         Self {
             language,
-            node_condition
+            node_condition,
         }
     }
 

--- a/harper-wasm/src/lib.rs
+++ b/harper-wasm/src/lib.rs
@@ -12,7 +12,7 @@ use wasm_bindgen::JsValue;
 static LINTER: Lazy<Mutex<LintGroup<Lrc<FullDictionary>>>> = Lazy::new(|| {
     Mutex::new(LintGroup::new(
         LintGroupConfig::default(),
-        FullDictionary::curated()
+        FullDictionary::curated(),
     ))
 });
 
@@ -63,7 +63,7 @@ pub fn lint(text: String) -> Vec<Lint> {
 pub fn apply_suggestion(
     text: String,
     span: Span,
-    suggestion: &Suggestion
+    suggestion: &Suggestion,
 ) -> Result<String, String> {
     let mut source: Vec<_> = text.chars().collect();
     let span: harper_core::Span = span.into();
@@ -96,13 +96,13 @@ pub fn apply_suggestion(
 
 #[wasm_bindgen]
 pub struct Suggestion {
-    inner: harper_core::linting::Suggestion
+    inner: harper_core::linting::Suggestion,
 }
 
 #[wasm_bindgen]
 pub enum SuggestionKind {
     Replace,
-    Remove
+    Remove,
 }
 
 #[wasm_bindgen]
@@ -117,14 +117,14 @@ impl Suggestion {
     pub fn get_replacement_text(&self) -> String {
         match &self.inner {
             harper_core::linting::Suggestion::Remove => "".to_string(),
-            harper_core::linting::Suggestion::ReplaceWith(chars) => chars.iter().collect()
+            harper_core::linting::Suggestion::ReplaceWith(chars) => chars.iter().collect(),
         }
     }
 
     pub fn kind(&self) -> SuggestionKind {
         match &self.inner {
             harper_core::linting::Suggestion::Remove => SuggestionKind::Remove,
-            harper_core::linting::Suggestion::ReplaceWith(_) => SuggestionKind::Replace
+            harper_core::linting::Suggestion::ReplaceWith(_) => SuggestionKind::Replace,
         }
     }
 }
@@ -132,7 +132,7 @@ impl Suggestion {
 #[wasm_bindgen]
 pub struct Lint {
     inner: harper_core::linting::Lint,
-    source: Lrc<Vec<char>>
+    source: Lrc<Vec<char>>,
 }
 
 #[wasm_bindgen]
@@ -175,7 +175,7 @@ impl Lint {
 #[wasm_bindgen]
 pub struct Span {
     pub start: usize,
-    pub end: usize
+    pub end: usize,
 }
 
 #[wasm_bindgen]

--- a/justfile
+++ b/justfile
@@ -53,14 +53,20 @@ package-vscode:
   yarn install -f
   yarn package-extension
 
+check-rust:
+  #! /bin/bash
+  set -eo pipefail
+
+  cargo fmt -- --check
+  cargo clippy -- -Dwarnings -D clippy::dbg_macro
+
 # Perform format and type checking.
 check:
   #! /bin/bash
   set -eo pipefail
 
-  cargo +nightly fmt --check
-  cargo clippy -- -Dwarnings -D clippy::dbg_macro
-
+  just check-rust
+  
   cd "{{justfile_directory()}}/packages"
   yarn install
   yarn prettier --check .

--- a/justfile
+++ b/justfile
@@ -1,6 +1,6 @@
 # Format entire project
 format:
-  cargo +nightly fmt  
+  cargo fmt  
   cd "{{justfile_directory()}}/packages"; yarn prettier -w .
 
 # Build the WebAssembly for a specific target (usually either `web` or `bundler`)
@@ -66,7 +66,7 @@ check:
   set -eo pipefail
 
   just check-rust
-  
+
   cd "{{justfile_directory()}}/packages"
   yarn install
   yarn prettier --check .

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "stable"
+targets = ["wasm32-unknown-unknown"]

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,14 +1,2 @@
 newline_style = "Unix"
 use_field_init_shorthand = true
-
-unstable_features = true
-combine_control_expr = false
-condense_wildcard_suffixes = true
-error_on_line_overflow = true
-error_on_unformatted = true
-format_strings = true
-imports_layout = "HorizontalVertical"
-imports_granularity = "Module"
-group_imports = "StdExternalCrate"
-wrap_comments = true
-trailing_comma = "Never"


### PR DESCRIPTION
This PR adds a `rust-toolchain.toml` and switches the repo to use stable rust. This also adds a `just check-rust` command which runs the rust-based lints.

Previous discussion in #180

(commits are just for semantic separation, we should squash merge, or I can squash myself).