### PR TITLE
fix(#198): limit tokio threads to 4 (+ main)

### DIFF
--- a/harper-ls/src/main.rs
+++ b/harper-ls/src/main.rs
@@ -31,7 +31,9 @@ struct Args {
     stdio: bool,
 }
 
-#[tokio::main]
+// Setting worker threads to 4 means the process will use about 5 threads total
+// This is because worker threads do not include blocking threads
+#[tokio::main(worker_threads = 4)]
 async fn main() -> anyhow::Result<()> {
     let subscriber = FmtSubscriber::builder()
         .map_writer(move |_| stderr)


### PR DESCRIPTION
[Tokio has two different types of threads](https://github.com/tokio-rs/tokio/discussions/3858#discussioncomment-869878):
- Worker threads: for async things
- Blocking threads: main and spawn_blocking

I limited the number of worker threads to 4, but the actual number of threads should hover around 5.
I'm not certain whether we spawn any blocking threads other than main, but if we do it should be minimal.
