### PR TITLE
Minor updates

### DIFF
--- a/.github/workflows/build_harper_ls.yml
+++ b/.github/workflows/build_harper_ls.yml
@@ -1,10 +1,10 @@
 name: Release
 
-on: 
-  push: 
-    branches: [ "master" ]
+on:
+  push:
+    branches: ["master"]
   pull_request:
-    branches: [ "master" ]
+    branches: ["master"]
 
 jobs:
   release:
@@ -18,39 +18,34 @@ jobs:
             bin: harper-ls.exe
             name: harper-ls-x86_64-pc-windows-msvc.zip
             command: build
-
           - release_for: macOS-x86_64
             os: macOS-latest
             target: x86_64-apple-darwin
             bin: harper-ls
             name: harper-ls-x86_64-apple-darwin.tar.gz
             command: build
-
           - release_for: macOS-aarch64
             os: macOS-latest
             target: aarch64-apple-darwin
             bin: harper-ls
             name: harper-ls-aarch64-apple-darwin.tar.gz
             command: build
-
           - release_for: Linux-x86_64-GNU
             os: ubuntu-20.04
             target: x86_64-unknown-linux-gnu
             bin: harper-ls
             name: harper-ls-x86_64-unknown-linux-gnu.tar.gz
             command: build
-            
           - release_for: Linux-aarch64-GNU
             os: ubuntu-20.04
             target: aarch64-unknown-linux-gnu
             bin: harper-ls
             name: harper-ls-aarch64-unknown-linux-gnu.tar.gz
             command: build
-
     runs-on: ${{ matrix.platform.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build binary
         uses: houseabsolute/actions-rust-cross@v0
         with:
@@ -77,6 +72,6 @@ jobs:
             github.ref == 'refs/tags/test-release' )
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
-        with: 
+        with:
           name: ${{ matrix.platform.bin }}-${{ matrix.platform.target }}
           path: harper-ls-*

--- a/.github/workflows/build_web.yml
+++ b/.github/workflows/build_web.yml
@@ -1,20 +1,19 @@
-name: 'Build Web'
+name: Build Web
 
 on:
   push:
-    branches: [ "master" ]
+    branches: ["master"]
   pull_request:
-    branches: [ "master" ]
+    branches: ["master"]
 
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v3
-    - uses: redhat-actions/buildah-build@v2
-      with:
-        image: web 
-        layers: false
-        containerfiles: |
-          Dockerfile
+      - uses: actions/checkout@v4
+      - uses: redhat-actions/buildah-build@v2
+        with:
+          image: web
+          layers: false
+          containerfiles: |
+            Dockerfile

--- a/.github/workflows/package_vscode_plugin.yml
+++ b/.github/workflows/package_vscode_plugin.yml
@@ -3,6 +3,8 @@ name: Package VS Code Plugin
 on:
   push:
     branches: ["master"]
+  pull_request:
+    branches: ["master"]
 
 jobs:
   package:

--- a/.github/workflows/package_vscode_plugin.yml
+++ b/.github/workflows/package_vscode_plugin.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   package:
+    name: Package - ${{ matrix.platform.code_target }}
     strategy:
       matrix:
         platform:
@@ -24,7 +25,6 @@ jobs:
           - os: ubuntu-20.04
             rust_target: aarch64-unknown-linux-gnu
             code_target: linux-arm64
-    name: Package - ${{ matrix.platform.code_target }}
     runs-on: ${{ matrix.platform.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -2,9 +2,9 @@ name: Precommit
 
 on:
   push:
-    branches: [ "master" ]
+    branches: ["master"]
   pull_request:
-    branches: [ "master" ]
+    branches: ["master"]
 
 env:
   CARGO_TERM_COLOR: always
@@ -12,14 +12,13 @@ env:
 jobs:
   precommit:
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
-      with:
-        node-version: 20
-    - uses: extractions/setup-just@v1
-    - name: Install `wasm-pack`
-      run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-    - name: Precommit
-      run: just precommit
+      - uses: actions/checkout@v4
+      - uses: extractions/setup-just@v2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install `wasm-pack`
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      - name: Precommit
+        run: just precommit

--- a/packages/vscode-plugin/CHANGELOG.md
+++ b/packages/vscode-plugin/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.12.0
 
 - `harper-ls` is now bundled with this extension, it no longer needs to be in your `PATH`.
 - `harper-ls` can now be manually restarted using the `harper.languageserver.restart` command.


### PR DESCRIPTION
- Change "Unreleased" section in `CHANGELOG.md` to "0.12.0". It seems this was left out in the last release.
- Format workflows with Prettier.
- Update actions to their latest versions. This should fix the warnings we get on runs about old Node.js versions.
- Run Package VS Code Plugin workflow on PRs.