### PR TITLE
Use standard "python" language id, add support for missing `.py` extension

### DIFF
--- a/harper-comments/src/comment_parser.rs
+++ b/harper-comments/src/comment_parser.rs
@@ -22,7 +22,7 @@ impl CommentParser {
             "rust" => tree_sitter_rust::language(),
             "typescriptreact" => tree_sitter_typescript::language_tsx(),
             "typescript" => tree_sitter_typescript::language_typescript(),
-            "py" => tree_sitter_python::language(),
+            "python" => tree_sitter_python::language(),
             "javascript" => tree_sitter_javascript::language(),
             "javascriptreact" => tree_sitter_typescript::language_tsx(),
             "go" => tree_sitter_go::language(),
@@ -65,6 +65,7 @@ impl CommentParser {
     /// [`Self::new_from_language_id`]
     fn filename_to_filetype(path: &Path) -> Option<&'static str> {
         Some(match path.extension()?.to_str()? {
+            "py" => "python",
             "rs" => "rust",
             "ts" => "typescript",
             "tsx" => "typescriptreact",


### PR DESCRIPTION
https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocumentItem has a list of language ids, and it recommends "python", not "py".
