### PR TITLE
Improve config change handling

### DIFF
--- a/harper-ls/src/backend.rs
+++ b/harper-ls/src/backend.rs
@@ -477,6 +477,22 @@ impl LanguageServer for Backend {
 
     async fn did_change_configuration(&self, params: DidChangeConfigurationParams) {
         self.update_config_from_obj(params.settings).await;
+
+        let urls: Vec<Url> = {
+            let mut doc_lock = self.doc_state.lock().await;
+            let config_lock = self.config.read().await;
+
+            for doc in doc_lock.values_mut() {
+                doc.linter = LintGroup::new(config_lock.lint_config, doc.dict.clone());
+            }
+
+            doc_lock.keys().cloned().collect()
+        };
+
+        for url in urls {
+            let _ = self.update_document_from_file(&url, None).await;
+            self.publish_diagnostics(&url).await;
+        }
     }
 
     async fn code_action(&self, params: CodeActionParams) -> Result<Option<CodeActionResponse>> {

--- a/packages/vscode-plugin/src/extension.ts
+++ b/packages/vscode-plugin/src/extension.ts
@@ -44,8 +44,9 @@ export async function activate(context: ExtensionContext): Promise<void> {
 	context.subscriptions.push(
 		workspace.onDidChangeConfiguration(async (event) => {
 			if (configs.find((c) => event.affectsConfiguration(c))) {
-				clientOptions.outputChannel?.appendLine('Configuration changed, restarting server');
-				await startLanguageServer();
+				await client?.sendNotification('workspace/didChangeConfiguration', {
+					settings: { 'harper-ls': workspace.getConfiguration('harper-ls') }
+				});
 			}
 		})
 	);

--- a/packages/vscode-plugin/src/tests/suite/integration.test.ts
+++ b/packages/vscode-plugin/src/tests/suite/integration.test.ts
@@ -47,8 +47,8 @@ describe('Integration >', () => {
 	it('updates diagnostics on configuration change', async () => {
 		const config = workspace.getConfiguration('harper-ls.linters');
 		await config.update('repeated_words', false, ConfigurationTarget.Workspace);
-		// Wait for `harper-ls` to restart and send new diagnostics
-		await sleep(1000);
+		// Wait for `harper-ls` to update diagnostics
+		await sleep(200);
 
 		compareActualVsExpectedDiagnostics(
 			getActualDiagnostics(markdownUri),

--- a/packages/vscode-plugin/src/tests/suite/integration.test.ts
+++ b/packages/vscode-plugin/src/tests/suite/integration.test.ts
@@ -48,7 +48,7 @@ describe('Integration >', () => {
 		const config = workspace.getConfiguration('harper-ls.linters');
 		await config.update('repeated_words', false, ConfigurationTarget.Workspace);
 		// Wait for `harper-ls` to update diagnostics
-		await sleep(200);
+		await sleep(250);
 
 		compareActualVsExpectedDiagnostics(
 			getActualDiagnostics(markdownUri),


### PR DESCRIPTION
I noticed that config updates don't get reflected in the editor unless `harper-ls` is restarted, at least for VSCode. Hence, my original solution to just restart it, but that feels like such a brute force way and it clears all the diagnostics within the workspace. So, I thought it'd be better if the new config is reflected and the diagnostics are updated when `did_change_configuration` is called.

P.S. This is my first time writing any Rust so I may have made a mistake somewhere.