### PR TITLE
ci: disable packaging and building workflows on draft PRs

### DIFF
--- a/.github/workflows/build_harper_ls.yml
+++ b/.github/workflows/build_harper_ls.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   release:
     name: Release - ${{ matrix.platform.release_for }}
+    if: github.event.pull_request.draft == false
     strategy:
       matrix:
         platform:

--- a/.github/workflows/package_vscode_plugin.yml
+++ b/.github/workflows/package_vscode_plugin.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   package:
     name: Package - ${{ matrix.platform.code_target }}
+    if: github.event.pull_request.draft == false
     strategy:
       matrix:
         platform:


### PR DESCRIPTION
These workflows fail on draft PRs anyway, and I believe they will get run when the draft status is removed.

I still think it's important to have the precommit workflow run, but these others don't seem too important for a draft.
